### PR TITLE
Feat/display eligible results

### DIFF
--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -189,7 +189,7 @@ const Results = ({ formData }) => {
             <p className='remember-disclaimer-label'>Remember that we can't guarantee eligibility, 
               but based on the information you provided, we believe you are likely eligible for the programs below:
             </p>
-            { displayProgramCards(results) }
+            { displayProgramCards(results.eligiblePrograms) }
           </>
         }
       </div>


### PR DESCRIPTION
What (if any) features are you implementing?
- Ability to only show the eligible programs based on the `eligible` property for each program.

What (if anything) did you refactor?
- I refactored state for the `Results` component to include `eligiblePrograms` and `ineligiblePrograms`.
- Added params and passed arguments to functions as necessary to account for refactored state.
- Removed the sorting functionality from the `displayProgramCards` and added that to the `fetchResults` function.

Please note that this was a pre-req before getting started on this feature given that the API is only returning eligible benefits at the moment:
Issue #38 `Feature: Add support for showing the list of accepted/declined messages`