### PR TITLE
Revert householdAssets to an initial state of 0

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,7 @@ const App = () => {
     expenses: [],
     householdSize: '',
     householdData: [],
-    householdAssets: '',
+    householdAssets: 0,
     lastTaxFilingYear: '',
     email: '',
     benefits: {

--- a/src/Assets/validationFunctions.js
+++ b/src/Assets/validationFunctions.js
@@ -112,7 +112,7 @@ const displayHouseholdSizeHelperText = (sizeOfHousehold) => {
 }
 
 const householdAssetsHasError = (householdAssets) => {
-  return householdAssets < 0 || householdAssets === '';
+  return householdAssets < 0;
 }
 
 const displayHouseholdAssetsHelperText = (householdAssets) => {


### PR DESCRIPTION
What (if anything) did you refactor?
- I reverted the initial state of `householdAssets` back to 0 since the bug was still present during testing. 