### PR TITLE
Fix 400 err by refactoring getHouseholdMemberBody expense props

### DIFF
--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -148,9 +148,9 @@ const Results = ({ results, setResults, formData, programSubset, passedOrFailedT
       medicaid: medicaid,
       disability_medicaid: disabilityRelatedMedicaid,
       has_income: hasIncome,
-      has_expenses: hasExpenses,
+      has_expenses: hasExpenses ? hasExpenses : false,
       income_streams: incomeStreams,
-      expenses: expenses
+      expenses: expenses ? expenses : []
     };
   };
 


### PR DESCRIPTION
What (if anything) did you refactor?
- I refactored the `getHouseholdMemberBody` function in the `Results` component to fix the `400: Bad Request` error that was being thrown as a result of individual household members not having the `has_expenses` and `expenses` properties in the request body to the `/householdmembers` endpoint.

