### PR TITLE
Remove semimonthly and yearly from frequency options

### DIFF
--- a/src/Assets/Languages/English.json
+++ b/src/Assets/Languages/English.json
@@ -257,8 +257,6 @@
   "frequencyOptions.weekly": "Every week",
   "frequencyOptions.biweekly": "Every 2 weeks",
   "frequencyOptions.monthly": "Every month",
-  "frequencyOptions.semimonthly": "Twice a month",
-  "frequencyOptions.yearly": "Every year",
   "results.return-screenerIdLabel": "Screener ID: ",
   "results.return-programsUpToLabel": " programs, up to ",
   "results.return-perYearOrLabel": " per year or ",

--- a/src/Assets/Languages/Spanish.json
+++ b/src/Assets/Languages/Spanish.json
@@ -257,8 +257,6 @@
   "frequencyOptions.weekly": "Semanal",
   "frequencyOptions.biweekly": "Cada 2 semanas",
   "frequencyOptions.monthly": "Cada mes",
-  "frequencyOptions.semimonthly": "Dos veces al mes",
-  "frequencyOptions.yearly": "Anual",
   "results.return-screenerIdLabel": "ID de cuestionario: ",
   "results.return-programsUpToLabel": " programas, hasta ",
   "results.return-perYearOrLabel": " por año o ",

--- a/src/Assets/frequencyOptions.js
+++ b/src/Assets/frequencyOptions.js
@@ -12,15 +12,7 @@ const frequencyOptions = {
   monthly: 
     <FormattedMessage 
       id='frequencyOptions.monthly' 
-      defaultMessage='Every month' />,
-  semimonthly: 
-    <FormattedMessage 
-      id='frequencyOptions.semimonthly' 
-      defaultMessage='Twice a month' />,
-  yearly: 
-    <FormattedMessage 
-      id='frequencyOptions.yearly' 
-      defaultMessage='Every year' />
+      defaultMessage='Every month' />
 };
 
 export default frequencyOptions;


### PR DESCRIPTION
ClickUp Ticket: https://app.clickup.com/t/3rgr80e

What (if anything) did you refactor?
- I refactored the `frequencyOptions` to remove the semimonthly and yearly options.

`Step 11` income dropdown in EN/ES:
<img width="1728" alt="Screen Shot 2022-11-03 at 3 42 06 PM" src="https://user-images.githubusercontent.com/86989161/199840482-41b39a54-c5f6-49f5-8cc0-15872231f7d9.png">

<img width="1728" alt="Screen Shot 2022-11-03 at 3 42 58 PM" src="https://user-images.githubusercontent.com/86989161/199840463-ebb22c0a-69be-46ab-8bed-390b6dd63555.png">

`Step 14` income dropdown in EN/ES:
<img width="1728" alt="Screen Shot 2022-11-03 at 3 43 52 PM" src="https://user-images.githubusercontent.com/86989161/199840442-5547ce59-9e34-4390-a996-efcf48a38683.png">

<img width="1724" alt="Screen Shot 2022-11-03 at 3 43 42 PM" src="https://user-images.githubusercontent.com/86989161/199840424-b6658098-d9c6-4ea6-9693-1fd88e49e258.png">
