### PR TITLE
Don't Display Benefits That the Household Has Already

### DIFF
--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -65,8 +65,9 @@ const Results = ({ results, setResults, formData, programSubset, passedOrFailedT
     const rawEligibilityResponse = await getEligibility(screensResponse.id, locale);
     const languageCode = locale.toLowerCase();
     const eligibilityResponse = rawEligibilityResponse.translations[languageCode];
-    const qualifiedPrograms = eligibilityResponse.filter((program) => program.eligible === true)
-      .sort((benefitA, benefitB) => benefitB.estimated_value - benefitA.estimated_value);
+    const qualifiedPrograms = eligibilityResponse
+			.filter((program) => program.eligible === true && !formData.benefits[program.name_abbreviated])
+			.sort((benefitA, benefitB) => benefitB.estimated_value - benefitA.estimated_value);
     const unqualifiedPrograms = eligibilityResponse.filter((program) => program.eligible === false);
 
     setResults({ 


### PR DESCRIPTION
What (if any) features are you implementing?
- Filtered out benefits that the user already says that they have.

What (if anything) did you refactor?
- Added a condition to check if the user has the benefit before marking it as eligible.

Any other comments, questions, or concerns?
- This did not work on the backend because the eligibility serializer only allowed Boolean datatypes.