### PR TITLE
Colorado Property Tax/Rent/Heat Credit Rebate Not Showing in Results

### DIFF
--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -314,7 +314,7 @@ const Results = ({ formData }) => {
       count++;
       let dataGridChild = {
         id: count,
-        path: [results[i].name, '/Detail'],
+        path: [results[i].name, 'Detail'],
         name: results[i].description,
         value: '',
         type: '',


### PR DESCRIPTION
Were there any issues that arose?
- We were creating the path for datagrid by splitting a string on slashes. So the name Colorado Property Tax/Rent/Heat Credit Rebate was creating wrong paths. I made the path an array to avoid this problem.
