### PR TITLE
Retain Language Preferences

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -314,9 +314,7 @@ const App = () => {
                 /> } />
             <Route
               path='/results/:id'
-              element={<Results
-                formData={formData}
-                /> } />
+              element={<Results/> } />
             <Route
               path='/email-results/:id'
               element={<EmailResults2

--- a/src/Components/Results/Results.js
+++ b/src/Components/Results/Results.js
@@ -33,10 +33,11 @@ export const isNavigationKey = (key) =>
   key.indexOf('Page') === 0 ||
   key === ' ';
 
-const Results = ({ formData }) => {
+const Results = () => {
   const { id: screenerId } = useParams()
   const navigate = useNavigate();
   const locale = useContext(Context).locale;
+  const setLocale = useContext(Context).setLocale;
   const intl = useIntl();
   const [filterResultsButton, setFilterResultsButton] = useState('benefits');
   const citizenToggleState = useState(false)
@@ -110,13 +111,16 @@ const Results = ({ formData }) => {
   }, [locale, results.rawResponse])
 
   const fetchResults = async () => {
-    const rawEligibilityResponse = await getEligibility(screenerId, locale);
-    setResults({
+		const rawEligibilityResponse = await getEligibility(screenerId, locale);
+		setLocale(
+			rawEligibilityResponse.default_language === 'en-us' ? 'en-US' : 'es'
+		);
+		setResults({
 			programs: [],
 			rawResponse: rawEligibilityResponse,
 			screenerId: rawEligibilityResponse.screen_id,
 		});
-  }
+	}
 
   const responseLanguage = () => {
     const { rawResponse } = results;

--- a/src/Components/Wrapper/Wrapper.js
+++ b/src/Components/Wrapper/Wrapper.js
@@ -21,6 +21,7 @@ const Wrapper = (props) => {
 
   useEffect(() => {
     localStorage.setItem('language', locale)
+    locale === 'en-US' ? setMessages(English) : setMessages(Spanish);
   }, [locale])
 
   const selectLanguage = (event) => {


### PR DESCRIPTION
What (if any) features are you implementing?
- Language is retained when the page is refreshed
- Use the language that the screen was submitted in to choose results language

Any other comments, questions, or concerns?
- The loading page could be in the wrong language because the results have not returned yet.