### PR TITLE
Refactor public charge link color

### DIFF
--- a/src/Components/LandingPage/LandingPage.css
+++ b/src/Components/LandingPage/LandingPage.css
@@ -2,3 +2,7 @@
   padding-inline-start: 2rem;
   margin-top: .5rem;
 }
+
+.public-charge-link {
+  color: #037493;
+}

--- a/src/Components/LandingPage/LandingPage.js
+++ b/src/Components/LandingPage/LandingPage.js
@@ -61,6 +61,7 @@ const LandingPage = ({ clearLocalStorageFormDataAndResults }) => {
 									defaultMessage="Non-U.S. citizens planning to apply for legal permanent residency or a visa should consider how applying for any benefits on this site may affect their immigration status. For more information, please review the "
 								/>
 								<a
+									className="public-charge-link"
 									variant="contained"
 									target="_blank"
 									href="https://cdhs.colorado.gov/public-charge-rule-and-colorado-immigrants#:~:text=About%20public%20charge&text=The%20test%20looks%20at%20whether,affidavit%20of%20support%20or%20contract."


### PR DESCRIPTION
What (if anything) did you refactor?
Changed the public charge link color on the landing page to be our new blue - #037493.

![image](https://user-images.githubusercontent.com/60552762/230425758-d9979686-90ca-4a51-a7bd-1fdf83fbd95e.png)
