### PR TITLE
Update student language for household steps

### DIFF
--- a/src/Assets/Languages/English.json
+++ b/src/Assets/Languages/English.json
@@ -137,7 +137,7 @@
   "householdDataBlock.createConditionsQuestion-do-these-apply-to-you": "Do any of these apply to you?",
   "householdDataBlock.createConditionsQuestion-do-these-apply": "Do any of these apply to them?",
   "householdDataBlock.createConditionsQuestion-pick": "It's OK to pick more than one.",
-  "conditionOptions.student": "Student",
+  "conditionOptions.student": "Student at a college, university, or other post-secondary institution",
   "conditionOptions.pregnant": "Pregnant",
   "conditionOptions.unemployed": "Unemployed",
   "conditionOptions.blindOrVisuallyImpaired": "Blind or visually impaired",

--- a/src/Assets/Languages/Spanish.json
+++ b/src/Assets/Languages/Spanish.json
@@ -137,7 +137,7 @@
   "householdDataBlock.createConditionsQuestion-do-these-apply-to-you": "¿Alguno de estos se aplica a usted?",
   "householdDataBlock.createConditionsQuestion-do-these-apply": "¿Cuál de las siguientes opciones corresponde?",
   "householdDataBlock.createConditionsQuestion-pick": "Puede elegir más de una opcion.",
-  "conditionOptions.student": "Estudiante",
+  "conditionOptions.student": "Estudiante en un colegio, universidad u otra institución postsecundaria",
   "conditionOptions.pregnant": "Embarazada",
   "conditionOptions.unemployed": "Sin empleo",
   "conditionOptions.blindOrVisuallyImpaired": "Ciego o con problemas de visión",

--- a/src/Assets/conditionOptions.js
+++ b/src/Assets/conditionOptions.js
@@ -4,7 +4,7 @@ const conditionOptions = {
   student:
     <FormattedMessage
       id='conditionOptions.student'
-      defaultMessage='Student' />,
+      defaultMessage='Student at a college, university, or other post-secondary institution' />,
   pregnant:
     <FormattedMessage
       id='conditionOptions.pregnant'


### PR DESCRIPTION
What (if anything) did you refactor?
I refactored the student language for household steps to "Student at a college, university, or other post-secondary institution"

![image](https://user-images.githubusercontent.com/60552762/230497229-52e65805-94fb-4128-ad43-a53533c56003.png)

