### PR TITLE
Remove Tax Help CO from referralOptions

### DIFF
--- a/src/Assets/Languages/English.json
+++ b/src/Assets/Languages/English.json
@@ -334,6 +334,7 @@
   "benefitOptions.cccap": "Help with child care costs (Colorado Child Care Assistance Program)",
   "benefitOptions.mydenver": "Reduced-cost youth programs (MY Denver Card)",
   "benefitOptions.leap": "Help with winter heating bills (LEAP)",
+  "referralOptions.testOrProspect": "Test or Prospective Partner",
   "referralOptions.searchEngine": "Google or other search engine",
   "referralOptions.other": "Other",
   "signUpOptions.sendUpdates": "Please notify me when new benefits become available that I am likely eligible for based on the information I have provided.",

--- a/src/Assets/Languages/Spanish.json
+++ b/src/Assets/Languages/Spanish.json
@@ -336,6 +336,7 @@
   "benefitOptions.cccap": "Ayuda con los costos de cuidado infantil (Programa de asistencia para el cuidado infantil de Colorado)",
   "benefitOptions.mydenver": "Programas para jóvenes de costo reducido (MY Denver Card)",
   "benefitOptions.leap": "Ayuda con las facturas de calefacción de invierno (LEAP)",
+  "referralOptions.testOrProspect": "Ensayador o Socio potencial",
   "referralOptions.searchEngine": "Google o otro motor de búsqueda",
   "referralOptions.other": "Otro",
   "signUpOptions.sendUpdates": "Por favor notifiqueme cuando nuevos beneficios estén disponibles que probablemente sea elegible, basado en la información que he proporcionado",

--- a/src/Assets/Languages/Vietnamese.json
+++ b/src/Assets/Languages/Vietnamese.json
@@ -334,6 +334,7 @@
   "benefitOptions.cccap": "Hỗ trợ chi phí trông trẻ (Chương Trình Hỗ Trợ Trông Trẻ Colorado)",
   "benefitOptions.mydenver": "Các chương trình giảm chi phí dành cho thanh thiếu niên (Thẻ MY Denver)",
   "benefitOptions.leap": "Trợ giúp về hóa đơn sưởi mùa đông (LEAP)",
+  "referralOptions.testOrProspect": "Kiểm tra hoặc Đối tác tiềm năng",
   "referralOptions.searchEngine": "Google hoặc công cụ tìm kiếm khác",
   "referralOptions.other": "Khác",
   "signUpOptions.sendUpdates": "Vui lòng thông báo cho tôi khi có các phúc lợi mới mà tôi có khả năng đủ điều kiện nhận dựa trên thông tin tôi đã cung cấp.",

--- a/src/Assets/referralOptions.js
+++ b/src/Assets/referralOptions.js
@@ -6,6 +6,10 @@ const referralOptions = {
   jeffcoPP: 'Jeffco Prosperity Partners',
   projectWorthmore: 'Project Worthmore',
   bia: 'Benefits in Action',
+  testOrProspect:
+    <FormattedMessage
+      id='referralOptions.testOrProspect'
+      defaultMessage='Test or Prospective Partner' />,
   searchEngine:
     <FormattedMessage
       id='referralOptions.searchEngine'


### PR DESCRIPTION
ClickUp Tickets: https://app.clickup.com/t/866a2qh8x & https://app.clickup.com/t/866a30mgj

What (if anything) did you refactor?
- I removed the `taxAssistanceSite` option & added `testOrProspect` in the `referralOptions`.

Is there anything that you need from your teammate?
- Please review and let me know if you have any questions or concerns.

Updated `referralOptions` without `Tax Assistance Site (VITA/Tax Help Colorado)` &  newly added `Test or Prospective Partner`:
<img width="1199" alt="Screenshot 2023-04-26 at 1 53 42 PM" src="https://user-images.githubusercontent.com/86989161/234687938-420ad252-b6e0-4f8a-86c6-9f3ff30e93a8.png">

