### PR TITLE
Add aria label to progress bar

### DIFF
--- a/src/Components/ProgressBar/ProgressBar.js
+++ b/src/Components/ProgressBar/ProgressBar.js
@@ -28,6 +28,7 @@ const ProgressBar = () => {
 				variant="determinate"
 				value={(step / totalSteps) * 100}
 				className="progress-bar"
+				aria-label='Progress Bar'
 			/>
 			<p className='step-progress-title'>
 				<FormattedMessage


### PR DESCRIPTION
What (if anything) did you refactor?
Added aria label to get rid of this accessibility flag: 
<img width="289" alt="image" src="https://user-images.githubusercontent.com/60552762/235757007-786f3bc2-8c61-4210-8044-9c1a221f0d16.png">

Any other comments, questions, or concerns?
Passed the accessibility audit on my local, please run Axe Dev Tools to verify this.