### PR TITLE
IL: Fix Moms and Babies Eligibility (FE)

### DIFF
--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -172,7 +172,10 @@ const Results = ({ type }: ResultsProps) => {
   const [validations, setValidations] = useState<Validation[]>([]);
   const energyCalculatorRebateCategories = useFetchEnergyCalculatorRebates();
 
-  const filterPrograms = filterProgramsGenerator(formData, filtersChecked, isAdminView);
+  const filterPrograms = useMemo(
+    () => filterProgramsGenerator(formData, filtersChecked, isAdminView, apiResults?.programs || []),
+    [formData, filtersChecked, isAdminView, apiResults?.programs]
+  );
 
   useEffect(() => {
     if (apiResults === undefined) {
@@ -197,7 +200,7 @@ const Results = ({ type }: ResultsProps) => {
     setMissingPrograms(apiResults.missing_programs);
     setValidations(apiResults.validations);
     setLoading(false);
-  }, [filtersChecked, apiResults, isAdminView]);
+  }, [filterPrograms, apiResults]);
 
   const ResultsContextProvider = ({ children }: PropsWithChildren) => {
     return (

--- a/src/Components/Results/filterPrograms.test.ts
+++ b/src/Components/Results/filterPrograms.test.ts
@@ -1,0 +1,377 @@
+import filterProgramsGenerator from './filterPrograms';
+import {
+  createProgram,
+  createFormData,
+  createFiltersChecked,
+  createProgramWithExclusions,
+  createProgramWithMembers,
+  createMemberEligibility,
+} from './testHelpers';
+import { Program } from '../../Types/Results';
+
+// Polyfill for structuredClone in test environment
+if (!global.structuredClone) {
+  global.structuredClone = (obj: any) => JSON.parse(JSON.stringify(obj));
+}
+
+// Mock dependencies
+jest.mock('./FormattedValue', () => ({
+  programValue: (program: Program) => {
+    let total = program.household_value;
+    for (const member of program.members) {
+      if (!member.already_has) {
+        total += member.value;
+      }
+    }
+    return total;
+  },
+}));
+
+jest.mock('./Results', () => ({
+  findMemberEligibilityMember: jest.fn(() => ({
+    age: 30,
+    relationship: 'yourself',
+    student: false,
+    pregnant: false,
+    blind: false,
+    disabled: false,
+    veteran: false,
+  })),
+}));
+
+describe('filterProgramsGenerator', () => {
+  const defaultFormData = createFormData();
+  const defaultFilters = createFiltersChecked();
+
+  describe('Basic filtering without exclusions', () => {
+    it('should show eligible programs with value', () => {
+      const programs = [
+        createProgram({ program_id: 1, eligible: true, household_value: 100 }),
+        createProgram({ program_id: 2, eligible: false, household_value: 100 }),
+        createProgram({ program_id: 3, eligible: true, household_value: 0 }),
+      ];
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
+      const filtered = filterPrograms(programs);
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].program_id).toBe(1);
+    });
+
+    it('should hide programs that user already has', () => {
+      const programs = [
+        createProgram({ program_id: 1, eligible: true, household_value: 100, already_has: false }),
+        createProgram({ program_id: 2, eligible: true, household_value: 100, already_has: true }),
+      ];
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
+      const filtered = filterPrograms(programs);
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].program_id).toBe(1);
+    });
+
+    it('should filter by legal status', () => {
+      const programs = [
+        createProgram({ program_id: 1, legal_status_required: ['citizen'], household_value: 100 }),
+        createProgram({ program_id: 2, legal_status_required: ['non_citizen'], household_value: 100 }),
+        createProgram({ program_id: 3, legal_status_required: ['citizen', 'non_citizen'], household_value: 100 }),
+      ];
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
+      const filtered = filterPrograms(programs);
+
+      expect(filtered).toHaveLength(2);
+      expect(filtered.map(p => p.program_id)).toEqual([1, 3]);
+    });
+
+    it('should show all programs in admin view', () => {
+      const programs = [
+        createProgram({ program_id: 1, eligible: false }),
+        createProgram({ program_id: 2, household_value: 0 }),
+        createProgram({ program_id: 3, already_has: true }),
+      ];
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, true, programs);
+      const filtered = filterPrograms(programs);
+
+      expect(filtered).toHaveLength(3);
+    });
+  });
+
+  describe('Program exclusion logic', () => {
+    it('should exclude programs when excluder is visible', () => {
+      const programs = [
+        createProgramWithExclusions(1, 'Program A', [2], true, 100),
+        createProgramWithExclusions(2, 'Program B', [], true, 100),
+      ];
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
+      const filtered = filterPrograms(programs);
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].program_id).toBe(1);
+    });
+
+    it('should show excluded program when excluder is not visible', () => {
+      const programs = [
+        createProgramWithExclusions(1, 'Program A', [2], false, 100), // Not eligible
+        createProgramWithExclusions(2, 'Program B', [], true, 100),
+      ];
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
+      const filtered = filterPrograms(programs);
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].program_id).toBe(2);
+    });
+
+    it('should handle mutual exclusions (first wins)', () => {
+      const programs = [
+        createProgramWithExclusions(1, 'Program A', [2], true, 100),
+        createProgramWithExclusions(2, 'Program B', [1], true, 100),
+      ];
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
+      const filtered = filterPrograms(programs);
+
+      // With mutual exclusions, the first program evaluated wins
+      // Program 2 is evaluated first due to being excluded by 1, finds 1 not yet evaluated, so is visible
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].program_id).toBe(2);
+    });
+
+    it('should handle transitive exclusions', () => {
+      const programs = [
+        createProgramWithExclusions(1, 'Program A', [2], true, 100),
+        createProgramWithExclusions(2, 'Program B', [3], true, 100),
+        createProgramWithExclusions(3, 'Program C', [], true, 100),
+      ];
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
+      const filtered = filterPrograms(programs);
+
+      // Program A excludes B, but B's exclusion of C doesn't matter since B is not visible
+      // So we should see programs A and C
+      expect(filtered).toHaveLength(2);
+      expect(filtered.map(p => p.program_id).sort()).toEqual([1, 3]);
+    });
+
+    it('should handle complex exclusion chains', () => {
+      const programs = [
+        createProgramWithExclusions(1, 'Program A', [3, 4], true, 100),
+        createProgramWithExclusions(2, 'Program B', [4], true, 100),
+        createProgramWithExclusions(3, 'Program C', [], true, 100),
+        createProgramWithExclusions(4, 'Program D', [], true, 100),
+      ];
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
+      const filtered = filterPrograms(programs);
+
+      // Programs 1 and 2 should be visible, 3 and 4 should be excluded
+      expect(filtered).toHaveLength(2);
+      expect(filtered.map(p => p.program_id).sort()).toEqual([1, 2]);
+    });
+
+    it('should handle circular exclusion dependencies', () => {
+      const programs = [
+        createProgramWithExclusions(1, 'Program A', [2], true, 100),
+        createProgramWithExclusions(2, 'Program B', [3], true, 100),
+        createProgramWithExclusions(3, 'Program C', [1], true, 100),
+      ];
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
+      const filtered = filterPrograms(programs);
+
+      // In a circular dependency, the evaluation order matters
+      // Programs get evaluated based on reverse exclusion checking
+      expect(filtered).toHaveLength(2);
+    });
+
+    it('should not apply exclusions in admin view', () => {
+      const programs = [
+        createProgramWithExclusions(1, 'Program A', [2], true, 100),
+        createProgramWithExclusions(2, 'Program B', [], true, 100),
+      ];
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, true, programs);
+      const filtered = filterPrograms(programs);
+
+      expect(filtered).toHaveLength(2);
+    });
+  });
+
+  describe('Immigration status filtering with exclusions', () => {
+    it('should apply exclusions based on immigration status filters', () => {
+      const programs = [
+        createProgram({
+          program_id: 1,
+          name_abbreviated: 'MOMS_CITIZEN',
+          legal_status_required: ['citizen'],
+          eligible: true,
+          household_value: 100,
+          excludes_programs: [2],
+        }),
+        createProgram({
+          program_id: 2,
+          name_abbreviated: 'MOMS_NONCITIZEN',
+          legal_status_required: ['non_citizen'],
+          eligible: true,
+          household_value: 100,
+          excludes_programs: [1],
+        }),
+      ];
+
+      // Test with 'citizen' filter only
+      const citizenFilters = createFiltersChecked({ citizen: true, non_citizen: false });
+      const filterPrograms1 = filterProgramsGenerator(defaultFormData, citizenFilters, false, programs);
+      const filtered1 = filterPrograms1(programs);
+
+      expect(filtered1).toHaveLength(1);
+      expect(filtered1[0].program_id).toBe(1);
+
+      // Test with 'non_citizen' filter only
+      const nonCitizenFilters = createFiltersChecked({ citizen: false, non_citizen: true });
+      const filterPrograms2 = filterProgramsGenerator(defaultFormData, nonCitizenFilters, false, programs);
+      const filtered2 = filterPrograms2(programs);
+
+      expect(filtered2).toHaveLength(1);
+      expect(filtered2[0].program_id).toBe(2);
+
+      // Test with both filters - both programs meet criteria, but mutual exclusion applies
+      const bothFilters = createFiltersChecked({ citizen: true, non_citizen: true });
+      const filterPrograms3 = filterProgramsGenerator(defaultFormData, bothFilters, false, programs);
+      const filtered3 = filterPrograms3(programs);
+
+      // With mutual exclusions and both filters, both programs meet criteria
+      // But mutual exclusion means only one will be shown
+      expect(filtered3).toHaveLength(1);
+    });
+
+    it('should handle member-level eligibility with exclusions', () => {
+      const programs = [
+        createProgramWithMembers(1, 'Family Program', { 'member1': 50, 'member2': 50 }, ['citizen']),
+        createProgramWithMembers(2, 'Individual Program', { 'member1': 100 }, ['citizen']),
+      ];
+
+      programs[0].excludes_programs = [2];
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
+      const filtered = filterPrograms(programs);
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].program_id).toBe(1);
+    });
+  });
+
+  describe('Performance and caching', () => {
+    it('should cache visibility results for performance', () => {
+      // Create a complex exclusion graph
+      const programs = Array.from({ length: 10 }, (_, i) => 
+        createProgramWithExclusions(
+          i + 1,
+          `Program ${i + 1}`,
+          i < 9 ? [i + 2] : [], // Each excludes the next
+          true,
+          100
+        )
+      );
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
+      
+      // Run filter twice to test caching
+      const filtered1 = filterPrograms(programs);
+      const filtered2 = filterPrograms(programs);
+
+      // Results should be consistent
+      expect(filtered1).toEqual(filtered2);
+      // With chain exclusions, programs that don't exclude others should be visible
+      expect(filtered1.length).toBeGreaterThan(0);
+    });
+
+    it('should handle missing program references gracefully', () => {
+      const programs = [
+        createProgramWithExclusions(1, 'Program A', [999], true, 100), // Excludes non-existent program
+        createProgramWithExclusions(2, 'Program B', [], true, 100),
+      ];
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
+      const filtered = filterPrograms(programs);
+
+      expect(filtered).toHaveLength(2);
+    });
+
+    it('should handle empty exclusions array', () => {
+      const programs = [
+        createProgram({ program_id: 1, excludes_programs: [], eligible: true, household_value: 100 }),
+        createProgram({ program_id: 2, excludes_programs: null, eligible: true, household_value: 100 }),
+      ];
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
+      const filtered = filterPrograms(programs);
+
+      expect(filtered).toHaveLength(2);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle programs with same eligibility criteria but different exclusions', () => {
+      const programs = [
+        createProgram({
+          program_id: 1,
+          legal_status_required: ['citizen'],
+          eligible: true,
+          household_value: 100,
+          excludes_programs: [3],
+        }),
+        createProgram({
+          program_id: 2,
+          legal_status_required: ['citizen'],
+          eligible: true,
+          household_value: 100,
+          excludes_programs: [4],
+        }),
+        createProgram({
+          program_id: 3,
+          legal_status_required: ['citizen'],
+          eligible: true,
+          household_value: 100,
+        }),
+        createProgram({
+          program_id: 4,
+          legal_status_required: ['citizen'],
+          eligible: true,
+          household_value: 100,
+        }),
+      ];
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
+      const filtered = filterPrograms(programs);
+
+      // Programs 1 and 2 should be visible
+      // Program 3 is excluded by 1, Program 4 is excluded by 2
+      expect(filtered).toHaveLength(2);
+      expect(filtered.map(p => p.program_id).sort()).toEqual([1, 2]);
+    });
+
+    it('should maintain member eligibility modifications through filtering', () => {
+      const member1 = createMemberEligibility('member1', true, 100);
+      const program = createProgram({
+        program_id: 1,
+        members: [member1],
+        legal_status_required: ['citizen'],
+        eligible: true,
+      });
+
+      const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, [program]);
+      const filtered = filterPrograms([program]);
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].members[0]).toMatchObject({
+        frontend_id: 'member1',
+        eligible: true,
+        value: 100,
+      });
+    });
+  });
+});

--- a/src/Components/Results/filterPrograms.test.ts
+++ b/src/Components/Results/filterPrograms.test.ts
@@ -135,10 +135,9 @@ describe('filterProgramsGenerator', () => {
       const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
       const filtered = filterPrograms(programs);
 
-      // With mutual exclusions, the first program evaluated wins
-      // Program 2 is evaluated first due to being excluded by 1, finds 1 not yet evaluated, so is visible
+      // With mutual exclusions, the first program in the array wins
       expect(filtered).toHaveLength(1);
-      expect(filtered[0].program_id).toBe(2);
+      expect(filtered[0].program_id).toBe(1);
     });
 
     it('should handle transitive exclusions', () => {
@@ -183,9 +182,10 @@ describe('filterProgramsGenerator', () => {
       const filterPrograms = filterProgramsGenerator(defaultFormData, defaultFilters, false, programs);
       const filtered = filterPrograms(programs);
 
-      // In a circular dependency, the evaluation order matters
-      // Programs get evaluated based on reverse exclusion checking
-      expect(filtered).toHaveLength(2);
+      // In circular dependencies: A excludes B, B excludes C, C excludes A
+      // First program (A) excludes B, then C excludes A, leaving only C
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].program_id).toBe(3);
     });
 
     it('should not apply exclusions in admin view', () => {

--- a/src/Components/Results/filterPrograms.ts
+++ b/src/Components/Results/filterPrograms.ts
@@ -9,6 +9,12 @@ import { programValue } from './FormattedValue';
 import { findMemberEligibilityMember } from './Results';
 
 /**
+ * Safe clone helper that falls back to JSON clone when structuredClone is not available
+ */
+const clone = <T>(obj: T): T =>
+  typeof structuredClone === 'function' ? structuredClone(obj) : JSON.parse(JSON.stringify(obj));
+
+/**
  * Gets the names of filters that are currently checked
  */
 function getCheckedFilterNames(filtersChecked: Record<CitizenLabels, boolean>): string[] {
@@ -43,7 +49,7 @@ function updateMemberEligibilities(
 ): Program[] {
   const checkedNonCalculatedFilters = getCheckedNonCalculatedFilterNames(filtersChecked);
   
-  return structuredClone(programs).map(program => {
+  return clone(programs).map(program => {
     // If program meets legal status with non-calculated filters, no need to check members
     const meetsBasicLegalStatus = program.legal_status_required.some(status => 
       checkedNonCalculatedFilters.includes(status)

--- a/src/Components/Results/testHelpers.ts
+++ b/src/Components/Results/testHelpers.ts
@@ -1,0 +1,132 @@
+import { Program, Translation, MemberEligibility } from '../../Types/Results';
+import { FormData } from '../../Types/FormData';
+import { CitizenLabels } from '../../Assets/citizenshipFilterFormControlLabels';
+
+export const createTranslation = (text: string): Translation => ({
+  default_message: text,
+  label: text,
+});
+
+export const createMemberEligibility = (
+  id: string,
+  eligible: boolean = true,
+  value: number = 100,
+  already_has: boolean = false
+): MemberEligibility => ({
+  frontend_id: id,
+  eligible,
+  value,
+  already_has,
+});
+
+export const createProgram = (overrides: Partial<Program> = {}): Program => ({
+  program_id: 1,
+  name: createTranslation('Test Program'),
+  name_abbreviated: 'TP',
+  external_name: 'test_program',
+  estimated_value: 100,
+  household_value: 0,
+  estimated_delivery_time: createTranslation('1-2 weeks'),
+  estimated_application_time: createTranslation('30 minutes'),
+  description_short: createTranslation('Short description'),
+  description: createTranslation('Long description'),
+  value_type: createTranslation('monthly'),
+  learn_more_link: createTranslation('http://example.com'),
+  apply_button_link: createTranslation('http://example.com/apply'),
+  apply_button_description: createTranslation('Apply now'),
+  legal_status_required: ['citizen'],
+  estimated_value_override: createTranslation(''),
+  eligible: true,
+  members: [],
+  failed_tests: [],
+  passed_tests: [],
+  already_has: false,
+  new: false,
+  low_confidence: false,
+  navigators: [],
+  documents: [],
+  warning_messages: [],
+  required_programs: [],
+  excludes_programs: null,
+  value_format: null,
+  ...overrides,
+});
+
+export const createFormData = (overrides: Partial<FormData> = {}): FormData => ({
+  isTest: false,
+  frozen: false,
+  agreeToTermsOfService: true,
+  is13OrOlder: true,
+  zipcode: '60601',
+  county: 'Cook',
+  startTime: new Date().toISOString(),
+  hasExpenses: 'false',
+  expenses: [],
+  householdSize: 1,
+  householdData: [],
+  householdAssets: 0,
+  hasBenefits: 'false',
+  benefits: [],
+  signUpInfo: {
+    email: '',
+    phone: '',
+    firstName: '',
+    lastName: '',
+    hasUser: false,
+    sendOffers: false,
+    sendUpdates: false,
+    commConsent: false,
+  },
+  acuteHHConditions: {},
+  referrerCode: '',
+  immutableReferrer: '',
+  ...overrides,
+} as FormData);
+
+export const createFiltersChecked = (
+  overrides: Partial<Record<CitizenLabels, boolean>> = {}
+): Record<CitizenLabels, boolean> => ({
+  citizen: true,
+  non_citizen: false,
+  green_card: false,
+  gc_5plus: false,
+  gc_5less: false,
+  refugee: false,
+  otherWithWorkPermission: false,
+  ...overrides,
+} as Record<CitizenLabels, boolean>);
+
+export const createProgramWithExclusions = (
+  id: number,
+  name: string,
+  excludes: number[] = [],
+  eligible: boolean = true,
+  value: number = 100
+): Program => createProgram({
+  program_id: id,
+  name: createTranslation(name),
+  name_abbreviated: name.substring(0, 3).toUpperCase(),
+  eligible,
+  estimated_value: value,
+  household_value: value,
+  excludes_programs: excludes.length > 0 ? excludes : null,
+});
+
+export const createProgramWithMembers = (
+  id: number,
+  name: string,
+  memberValues: { [key: string]: number },
+  legalStatus: string[] = ['citizen']
+): Program => {
+  const members = Object.entries(memberValues).map(([memberId, value]) =>
+    createMemberEligibility(memberId, true, value)
+  );
+  
+  return createProgram({
+    program_id: id,
+    name: createTranslation(name),
+    members,
+    legal_status_required: legalStatus,
+    household_value: 0,
+  });
+};

--- a/src/Types/Results.ts
+++ b/src/Types/Results.ts
@@ -67,6 +67,7 @@ export type Program = {
   documents: ProgramDocument[];
   warning_messages: WarningMsg[];
   required_programs: number[];
+  excludes_programs: number[];
   value_format: string | null;
 };
 

--- a/src/Types/Results.ts
+++ b/src/Types/Results.ts
@@ -67,7 +67,7 @@ export type Program = {
   documents: ProgramDocument[];
   warning_messages: WarningMsg[];
   required_programs: number[];
-  excludes_programs: number[];
+  excludes_programs?: number[] | null;
   value_format: string | null;
 };
 


### PR DESCRIPTION




## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

These changes enable the FE to handle the new `excludes_programs` field from the BE, so that programs can be mutually exclusive and account for immigration status filters.

- Fixes https://github.com/MyFriendBen/benefits-api/issues/1085
- Related PR: https://github.com/MyFriendBen/benefits-api/pull/1128

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Update `filterProgramsGenerator` to create a cache of program visibility and use the new `excludes_programs` field to determine if another program's eligibility should result in a given program being hidden

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: **Related PR**'s migration
- Configuration updates needed: None
- Environment variables/settings to add: None

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script: None
- Update production config: None
- Admin updates needed: None

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

See limitations and future considerations outlined in **Related PR**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Results now enforce cross-program exclusions so conflicting programs are hidden when excluded by another visible program.
  - Program data accepts an optional exclusions field to drive exclusion behavior.

- Refactor
  - Results filtering decomposed into clear stages and memoized to reduce recomputation; updates now trigger only on relevant input or API changes.

- Tests
  - Comprehensive test suite and helpers added to validate exclusion logic, visibility rules, member eligibility, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->