### PR TITLE
IL: Add state tax credits to step 8

### DIFF
--- a/src/Assets/updateFormData.tsx
+++ b/src/Assets/updateFormData.tsx
@@ -36,6 +36,8 @@ export function useUpdateFormData() {
         denverpresc: response.has_dpp ?? false,
         ede: response.has_ede ?? false,
         eitc: response.has_eitc ?? false,
+        il_eitc: response.has_il_eitc ?? false,
+        il_ctc: response.has_il_ctc ?? false,
         lifeline: response.has_lifeline ?? false,
         leap: response.has_leap ?? false,
         nc_lieap: response.has_nc_lieap ?? false,

--- a/src/Assets/updateScreen.ts
+++ b/src/Assets/updateScreen.ts
@@ -48,6 +48,8 @@ const getScreensBody = (formData: FormData, languageCode: Language, whiteLabel: 
     has_dpp: formData.benefits.denverpresc ?? null,
     has_ede: formData.benefits.ede ?? null,
     has_eitc: formData.benefits.eitc ?? null,
+    has_il_eitc: formData.benefits.il_eitc ?? null,
+    has_il_ctc: formData.benefits.il_ctc ?? null,
     has_erc: null,
     has_lifeline: formData.benefits.lifeline ?? null,
     has_leap: formData.benefits.leap ?? null,

--- a/src/Types/ApiFormData.ts
+++ b/src/Types/ApiFormData.ts
@@ -156,9 +156,11 @@ export type ApiFormData = {
   has_lifeline: boolean | null;
   has_acp: boolean | null;
   has_eitc: boolean | null;
+  has_il_eitc: boolean | null;
   has_coeitc: boolean | null;
   has_nslp: boolean | null;
   has_ctc: boolean | null;
+  has_il_ctc: boolean | null;
   has_medicaid?: boolean | null;
   has_rtdlive: boolean | null;
   has_cccap: boolean | null;


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

These changes (in combination with the BE changes in the related PR) allow users to select IL CTC and IL EITC as current benefits and prevent them showing up in the results in that case.

- Fixes: https://linear.app/myfriendben/issue/MFB-194/il-add-state-tax-credits-to-step-8-does-your-household-currently-have

- Related PR: https://github.com/MyFriendBen/benefits-api/pull/1137

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Submit `has_il_eitc` and `has_il_ctc` form data
- Handle API responses with `has_il_eitc` and `has_il_ctc` fields

<img width="1009" height="183" alt="Screenshot 2025-08-27 at 3 58 57 PM" src="https://github.com/user-attachments/assets/ebcfc885-c5d5-4873-a049-49dac628b197" />

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:
    1. Visit the current benefits step
    2. Select IL EITC and IL CTC
    3. Click "Continue"
    4. Confirm that the programs display under **Current Household Benefits** in the next step

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script: None
- Update production config: None
- Admin updates needed: None

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations: None
- Future considerations: None
