### PR TITLE
Sonali/mfb 70 central default Income to "Yes" for users 16+ and add explanatory message

### DIFF
--- a/src/Components/Steps/HouseholdMembers/HouseholdMemberForm.tsx
+++ b/src/Components/Steps/HouseholdMembers/HouseholdMemberForm.tsx
@@ -261,6 +261,20 @@ const HouseholdMemberForm = () => {
       return 'true';
     }
 
+    // Check if the person is 16 years or older
+    const birthYear = householdMemberFormData?.birthYear;
+    const birthMonth = householdMemberFormData?.birthMonth;
+    
+    if (birthYear && birthMonth) {
+      const { CURRENT_MONTH, CURRENT_YEAR } = getCurrentMonthYear();
+      const age = CURRENT_YEAR - birthYear;
+      const is16OrOlder = age > 16 || (age === 16 && birthMonth <= CURRENT_MONTH);
+      
+      if (is16OrOlder) {
+        return 'true';
+      }
+    }
+
     return 'false';
   };
 
@@ -327,7 +341,28 @@ const HouseholdMemberForm = () => {
     if (!hasTruthyIncome) {
       replace([]);
     }
-  }, [watchHasIncome]);
+  }, [watchHasIncome, append, replace, getValues, hasTruthyIncome]);
+
+  // Check if user is 16+ when birth month/year changes and set hasIncome to 'true' if so
+  const watchBirthMonth = watch('birthMonth');
+  const watchBirthYear = watch('birthYear');
+  
+  useEffect(() => {
+    if (watchBirthMonth && watchBirthYear) {
+      const birthMonth = Number(watchBirthMonth);
+      const birthYear = Number(watchBirthYear);
+      
+      if (birthMonth > 0 && birthYear > 0) {
+        const { CURRENT_MONTH, CURRENT_YEAR } = getCurrentMonthYear();
+        const age = CURRENT_YEAR - birthYear;
+        const is16OrOlder = age > 16 || (age === 16 && birthMonth <= CURRENT_MONTH);
+        
+        if (is16OrOlder) {
+          setValue('hasIncome', 'true');
+        }
+      }
+    }
+  }, [watchBirthMonth, watchBirthYear, setValue]);
 
   const formSubmitHandler: SubmitHandler<FormSchema> = async (memberData) => {
     if (uuid === undefined) {
@@ -624,18 +659,28 @@ const HouseholdMemberForm = () => {
             control={control}
             rules={{ required: true }}
             render={({ field }) => (
-              <RadioGroup {...field} aria-label={translatedAriaLabel} sx={{ marginBottom: '1rem' }}>
-                <FormControlLabel
-                  value={'true'}
-                  control={<Radio />}
-                  label={<FormattedMessage id="radiofield.label-yes" defaultMessage="Yes" />}
-                />
-                <FormControlLabel
-                  value={'false'}
-                  control={<Radio />}
-                  label={<FormattedMessage id="radiofield.label-no" defaultMessage="No" />}
-                />
-              </RadioGroup>
+              <>
+                <RadioGroup {...field} aria-label={translatedAriaLabel} sx={{ marginBottom: '1rem' }}>
+                  <FormControlLabel
+                    value={'true'}
+                    control={<Radio />}
+                    label={<FormattedMessage id="radiofield.label-yes" defaultMessage="Yes" />}
+                  />
+                  <FormControlLabel
+                    value={'false'}
+                    control={<Radio />}
+                    label={<FormattedMessage id="radiofield.label-no" defaultMessage="No" />}
+                  />
+                </RadioGroup>
+                {watchHasIncome === 'false' && (
+                  <QuestionDescription>
+                    <FormattedMessage 
+                      id="householdDataBlock.createIncomeRadioQuestion-noIncomeDisclaimer" 
+                      defaultMessage="Your household income helps determine which benefits you qualify for and how much support you can receive." 
+                    />
+                  </QuestionDescription>
+                )}
+              </>
             )}
           />
         </div>


### PR DESCRIPTION
## Context & Motivation

- Fixes Linear issue MFB-70 : [Central: Default Income to "Yes" for 16+](https://linear.app/myfriendben/issue/MFB-70/central-default-income-to-yes-for-16)
-

## Changes Made

MFB-70: Default Income to "Yes" for users 16+ and add explanatory message

  - Added age calculation logic that sets income radio button to "Yes" when user is 16 years or older
  - Added dynamic detection of age when birth month/year are entered
  - Added explanatory message when "No" is selected to inform users why income information is important
  - Fixed dependency arrays in useEffect hooks to avoid potential bugs

## Testing

-  Migrations to run: None required
-  Configuration updates needed: None required
-  Environment variables/settings to add: None required
-Manual Testing Steps

   1.  Navigate to the Household Member form by         
          -  Completing the initial steps until you reach step-5 (household members data)
         -   If testing with multiple household members, proceed to the appropriate member
   2. Test age-based default selection
             For 16+ years old:
                     Enter a birth month and year that makes the person 16+ years old (e.g., May 2008 or earlier)
                     Verify that the "Do you have an income?" radio button automatically selects "Yes"
             For under 16 years old:
                     Enter a birth month and year that makes the person under 16 (e.g., June 2009 or later)
                     Verify that the "Do you have an income?" radio button remains set to "No"
   3. Test real-time updates
          - Start with a person under 16
          - Change the birth year to make them 16+
          - Verify that the radio button automatically switches to "Yes"
          - Test explanatory message display
     4. Select "No" for the "Do you have an income?" question
              - Verify that the message appears below the radio buttons
              - Confirm the message reads: "Your household income helps determine which benefits you qualify     for and how much support you can receive."
              - Verify that the message disappears when "Yes" is selected
        5. Test form submission
            - Complete the form and continue to the next step
            - Navigate back to the household member
            - Verify that the age-based default selection is preserved when returning to the form

These testing steps thoroughly validate both features we've implemented:
      The automatic selection of "Yes" for income when the household member is 16+ years old
      The explanatory message that appears when "No" is selected for income
            



