### PR TITLE
CO: Add first step

### DIFF
--- a/src/Assets/updateFormData.tsx
+++ b/src/Assets/updateFormData.tsx
@@ -91,6 +91,7 @@ export function useUpdateFormData() {
         jobResources: response.needs_job_resources ?? false,
         dentalCare: response.needs_dental_care ?? false,
         legalServices: response.needs_legal_services ?? false,
+        savings: response.needs_savings ?? false,
         veteranServices: response.needs_veteran_services ?? false,
       },
       signUpInfo: {

--- a/src/Assets/updateScreen.ts
+++ b/src/Assets/updateScreen.ts
@@ -102,6 +102,7 @@ const getScreensBody = (formData: FormData, languageCode: Language, whiteLabel: 
     needs_job_resources: formData.acuteHHConditions.jobResources ?? null,
     needs_dental_care: formData.acuteHHConditions.dentalCare ?? null,
     needs_legal_services: formData.acuteHHConditions.legalServices ?? null,
+    needs_savings: formData.acuteHHConditions.savings ?? null,
     needs_veteran_services: formData.acuteHHConditions.veteranServices ?? null,
     utm_id: formData.utm?.id ?? null,
     utm_source: formData.utm?.source ?? null,

--- a/src/Components/Config/configHook.tsx
+++ b/src/Components/Config/configHook.tsx
@@ -27,6 +27,7 @@ import { ReactComponent as Job_resources } from '../../Assets/icons/UrgentNeeds/
 import { ReactComponent as Legal_services } from '../../Assets/icons/UrgentNeeds/AcuteConditions/legal_services.svg';
 import { ReactComponent as Support } from '../../Assets/icons/UrgentNeeds/AcuteConditions/support.svg';
 import { ReactComponent as Military } from '../../Assets/icons/UrgentNeeds/AcuteConditions/military.svg';
+import { ReactComponent as Resources } from '../../Assets/icons/General/resources.svg';
 import { ReactComponent as SurvivingSpouse } from '../../Assets/icons/General/head.svg';
 import { ReactComponent as Dialysis } from '../../Assets/icons/General/OptionCard/Conditions/dialysis.svg';
 import { Language } from '../../Assets/languageOptions';
@@ -74,6 +75,9 @@ function transformItemIcon(item: unknown): any {
       break;
     case 'Military':
       iconComponent = <Military className={icon._classname} />;
+      break;
+    case 'Savings':
+      iconComponent = <Resources className={icon._classname} />;
       break;
     // Conditions
     case 'BlindOrVisuallyImpaired':

--- a/src/Components/Results/Needs/NeedCard.tsx
+++ b/src/Components/Results/Needs/NeedCard.tsx
@@ -1,9 +1,10 @@
 import { FormattedMessage, useIntl } from 'react-intl';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { UrgentNeed } from '../../../Types/Results';
 import ResultsTranslate from '../Translate/Translate';
 import { iconCategoryMap } from '../../CurrentBenefits/CurrentBenefits';
-import { formatPhoneNumber } from '../helpers';
+import { formatPhoneNumber, generateNeedId } from '../helpers';
 import './NeedCard.css';
 
 type NeedsCardProps = {
@@ -22,7 +23,26 @@ const getIcon = (messageType: string) => {
 
 const NeedCard = ({ need }: NeedsCardProps) => {
   const intl = useIntl();
+  const location = useLocation();
   const [infoIsOpen, setInfoIsOpen] = useState(false);
+
+  // Check if this need should be expanded based on URL hash
+  useEffect(() => {
+    const hash = location.hash;
+    if (hash) {
+      const targetNeedId = generateNeedId(need.name.default_message);
+      if (hash === `#${targetNeedId}`) {
+        setInfoIsOpen(true);
+        // Scroll to this element after a short delay to ensure it's rendered
+        setTimeout(() => {
+          const element = document.getElementById(targetNeedId);
+          if (element) {
+            element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          }
+        }, 100);
+      }
+    }
+  }, [location.hash, need.name.default_message]);
 
   let translatedLink = '';
   if (need.link.default_message !== '') {
@@ -36,8 +56,10 @@ const NeedCard = ({ need }: NeedsCardProps) => {
     defaultMessage: need.description.default_message,
   });
 
+  const needId = generateNeedId(need.name.default_message);
+
   return (
-    <div className="need-card-container">
+    <div id={needId} className="need-card-container">
       <div className="header-and-button-divider">
         <div className="result-resource-more-info">
           {icon}

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -23,6 +23,7 @@ import dataLayerPush from '../../Assets/analytics';
 import HelpButton from './211Button/211Button';
 import MoreHelp from '../MoreHelp/MoreHelp';
 import BackAndSaveButtons from './BackAndSaveButtons/BackAndSaveButtons';
+import UrgentNeedBanner from './UrgentNeedBanner/UrgentNeedBanner';
 import { FormattedMessage } from 'react-intl';
 import './Results.css';
 import { OTHER_PAGE_TITLES } from '../../Assets/pageTitleTags';
@@ -255,6 +256,7 @@ const Results = ({ type }: ResultsProps) => {
         <ResultsContextProvider>
           <ResultsHeader type={type} />
           <ResultsTabs />
+          {type === 'program' && <UrgentNeedBanner />}
           <Grid container sx={{ p: '1rem', mt: '2rem' }}>
             <Grid item xs={12}>
               {type === 'need' ? <Needs /> : <Programs />}

--- a/src/Components/Results/UrgentNeedBanner/UrgentNeedBanner.test.tsx
+++ b/src/Components/Results/UrgentNeedBanner/UrgentNeedBanner.test.tsx
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import UrgentNeedBanner from './UrgentNeedBanner';
+
+// Mock the Results context and defaultMessage
+jest.mock('../Results', () => ({
+  useResultsContext: () => ({ needs: [] }),
+  useResultsLink: () => '/results/near-term-needs',
+}));
+
+// Mock ResultsTranslate component
+jest.mock('../Translate/Translate', () => {
+  return ({ translation }: { translation: any }) => <span>{translation?.default_message || 'Default message'}</span>;
+});
+
+describe('UrgentNeedBanner', () => {
+  it('renders without crashing', () => {
+    render(
+      <IntlProvider locale="en" messages={{}}>
+        <UrgentNeedBanner />
+      </IntlProvider>
+    );
+  });
+
+  it('returns null when no needs are provided', () => {
+    const { container } = render(
+      <IntlProvider locale="en" messages={{}}>
+        <UrgentNeedBanner />
+      </IntlProvider>
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/Components/Results/UrgentNeedBanner/UrgentNeedBanner.tsx
+++ b/src/Components/Results/UrgentNeedBanner/UrgentNeedBanner.tsx
@@ -1,0 +1,91 @@
+import { Alert, Button, Stack, Typography } from '@mui/material';
+import { FormattedMessage } from 'react-intl';
+import { useContext } from 'react';
+import { NavLink } from 'react-router-dom';
+import { Context } from '../../Wrapper/Wrapper';
+import { useResultsContext, useResultsLink } from '../Results';
+import { UrgentNeed } from '../../../Types/Results';
+import ResultsTranslate from '../Translate/Translate';
+import { generateNeedId } from '../helpers';
+
+/**
+ * UrgentNeedBanner component displays notification banners for urgent needs
+ * that have notification messages configured
+ */
+const UrgentNeedBanner = () => {
+  const { needs } = useResultsContext();
+  const { theme } = useContext(Context);
+  const needsPageLink = useResultsLink('results/near-term-needs');
+  
+  // Filter urgent needs that have notification messages
+  const urgentNeedsWithNotifications = needs.filter(need => {
+    if (!need.notification_message) return false;
+    const message = need.notification_message.default_message;
+    return message && message.trim();
+  });
+  
+  if (urgentNeedsWithNotifications.length === 0) {
+    return null;
+  }
+  
+  return (
+    <Stack sx={{ 
+      width: '100%', 
+      px: '1rem',
+      marginTop: '2rem'
+    }} spacing={2}>
+      {urgentNeedsWithNotifications.map((need: UrgentNeed, index: number) => (
+        <Alert 
+          key={index}
+          severity="info" 
+          sx={{ 
+            backgroundColor: theme.secondaryBackgroundColor,
+            border: `2px solid ${theme.primaryColor}`,
+            '& .MuiAlert-icon': {
+              color: theme.primaryColor
+            },
+            '& .MuiAlert-message': {
+              width: '100%'
+            }
+          }}
+        > 
+          <Typography 
+            variant="body1" 
+            sx={{ 
+              mb: 2,
+              fontFamily: '"Open Sans", sans-serif',
+              lineHeight: 1.5
+            }}
+          >
+            <ResultsTranslate translation={need.notification_message!} />
+          </Typography>
+          
+          <Button 
+            component={NavLink}
+            to={`${needsPageLink}#${generateNeedId(need.name.default_message)}`}
+            variant="contained" 
+            sx={{ 
+              backgroundColor: 'var(--primary-color)',
+              color: 'white',
+              fontSize: '0.8rem',
+              px: { xs: 1.5, md: 2 }, // 0.5rem 0.75rem on mobile, 0.5rem 1rem on desktop
+              py: 1, // 0.5rem
+              borderRadius: '0.75rem',
+              textDecoration: 'none',
+              '&:hover': {
+                textDecoration: 'none'
+              }
+            }}
+          >
+            <FormattedMessage 
+              id="urgentNeedBanner.learnMore" 
+              defaultMessage="Learn More" 
+            />
+          </Button>
+        </Alert>
+      ))}
+    </Stack>
+  );
+};
+
+export default UrgentNeedBanner;

--- a/src/Components/Results/helpers.ts
+++ b/src/Components/Results/helpers.ts
@@ -5,3 +5,11 @@ export const formatPhoneNumber = (phoneNumber: string): string => {
 
   return `+${phoneNumber[1]}-${phoneNumber.slice(2, 5)}-${phoneNumber.slice(5, 8)}-${phoneNumber.slice(8)}`;
 };
+
+/**
+ * Generates a consistent HTML ID for an urgent need based on its name
+ * Used for URL anchoring and cross-component navigation between UrgentNeedBanner and NeedCard
+ */
+export const generateNeedId = (needName: string): string => {
+  return `need-${encodeURIComponent(needName.toLowerCase())}`;
+};

--- a/src/Components/Wrapper/Wrapper.tsx
+++ b/src/Components/Wrapper/Wrapper.tsx
@@ -79,6 +79,7 @@ const initialFormData: FormData = {
     jobResources: false,
     dentalCare: false,
     legalServices: false,
+    savings: false,
   },
 };
 

--- a/src/Types/ApiFormData.ts
+++ b/src/Types/ApiFormData.ts
@@ -219,6 +219,7 @@ export type ApiFormData = {
   needs_job_resources: boolean | null;
   needs_dental_care: boolean | null;
   needs_legal_services: boolean | null;
+  needs_savings: boolean | null;
   needs_veteran_services: boolean | null;
   utm_id: string | null;
   utm_source: string | null;

--- a/src/Types/Config.ts
+++ b/src/Types/Config.ts
@@ -63,6 +63,7 @@ export type ApiAcuteHHConditions = {
   jobResources: string;
   dentalCare: string;
   legalServices: string;
+  savings: string;
 };
 
 export type ApiSignupInfo = {

--- a/src/Types/Results.ts
+++ b/src/Types/Results.ts
@@ -96,6 +96,7 @@ export type UrgentNeed = {
   warning: Translation;
   phone_number: string;
   icon: string;
+  notification_message: Translation | null;
 };
 
 export type Validation = {


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

These changes support the new Savings for College option in step 9 and enable us to display a banner at the top of the results page with a link that focuses and expands a specific additional resource (triggered off of a `notification_message` being set on the UrgentNeed record.

- Fixes: https://linear.app/myfriendben/issue/MFB-72/co-add-first-step-to-additional-resources
- Related PR: https://github.com/MyFriendBen/benefits-api/pull/1158

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Support needs_savings field in requests/responses
- Reuse Resources icon for Savings
- Add UrgentNeedBanner to display notification message for an Urgent Need
- Add url-based scroll and expansion for additional resources to allow "Learn More" button in UrgentNeedBanner to direct user to relevant need

**First step with notification (when child is 0-2):**

https://github.com/user-attachments/assets/81e1e2ac-f0cc-4c0f-9fea-a535e516912f

**First step without notification (when child is 2-7):**

https://github.com/user-attachments/assets/d38778bd-a880-4141-8bc0-55e908c07789

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: See related PR
- Configuration updates needed: See admin updates
- Manual testing steps:
    * Create a screen for a household in CO with a child between 0-2 years old
    * Visit the results page
    * Verify that you see a notification banner about first step
    * Click the "Learn more" link
    * Verify that you are taken to the additional resources tab and scrolled to the expanded First Step resource

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Update production config: See related PR
- Admin updates needed: Add `notification_message` for `first_step_notifiable` urgent need in Admin UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Urgent Need Banner on program results, showing notifications with Learn More links.
  - Enabled deep linking to specific needs: cards auto-expand and scroll into view via URL hash.
  - Introduced Savings as a selectable near-term need with a dedicated icon.
  - Form now captures savings preference; results reflect savings-related guidance.

- Tests
  - Added unit tests for Urgent Need Banner behavior.
  - Added end-to-end tests covering Colorado First Step Savings scenarios (banner visibility and navigation).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->