### PR TITLE
Add "savings" to heading options mappings

### DIFF
--- a/src/Components/Results/CategoryHeading/CategoryHeading.tsx
+++ b/src/Components/Results/CategoryHeading/CategoryHeading.tsx
@@ -19,6 +19,7 @@ import { ReactComponent as Job_resources } from '../../../Assets/icons/UrgentNee
 import { ReactComponent as Legal_services } from '../../../Assets/icons/UrgentNeeds/AcuteConditions/legal_services.svg';
 import { ReactComponent as Support } from '../../../Assets/icons/UrgentNeeds/AcuteConditions/support.svg';
 import { ReactComponent as Military } from '../../../Assets/icons/UrgentNeeds/AcuteConditions/military.svg';
+import { ReactComponent as Resources } from '../../../Assets/icons/General/resources.svg';
 import { calculateTotalValue, formatToUSD } from '../FormattedValue';
 import { FormattedMessage, useIntl } from 'react-intl';
 import ResultsTranslate from '../Translate/Translate';
@@ -50,7 +51,8 @@ export const headingOptionsMappings: { [key: string]: React.ComponentType } = {
   job_resources: Job_resources,
   dental_care: Dental_care,
   legal_services: Legal_services,
-  veteran_services: Military, 
+  veteran_services: Military,
+  savings: Resources,
 };
 
 type CategoryHeadingProps = {


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

These changes add support for a new savings icon for the CO: First Step additional resource.

- Fixes: https://linear.app/myfriendben/issue/MFB-72/co-add-first-step-to-additional-resources
- Related PR: https://github.com/MyFriendBen/benefits-api/pull/1160

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Add mapping from `savings` to `Resource` icon

<img width="1292" height="304" alt="Screenshot 2025-09-16 at 4 13 31 PM" src="https://github.com/user-attachments/assets/d73297bf-55bc-4fb6-9088-093061a23022" />

## Testing

<!-- Steps needed to test this PR locally -->

- Configuration updates needed: See **Related PR**
- Manual testing steps:
    * Create a HH with a 3 year old child
    * Visit Results -> Additional resources
    * Verify that you see a piggy bank icon for First Step