### PR TITLE
Remove affiliate language from consent

### DIFF
--- a/src/Components/Steps/SignUp/SignUp.tsx
+++ b/src/Components/Steps/SignUp/SignUp.tsx
@@ -510,7 +510,7 @@ function SignUp() {
                           <strong>SMS: </strong>
                           <FormattedMessage
                             id="signUp.displayDisclosureSection.tcpa"
-                            defaultMessage="I consent to MyFriendBen and its affiliates contacting me via text message to offer additional programs or opportunities that may be of interest to me and my family, for marketing purposes, updates and alerts, and to solicit feedback. I understand that the frequency of these text messages may vary, and that standard message and data costs may apply. Reply HELP for help and STOP to end. View our <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>."
+                            defaultMessage="I consent to MyFriendBen contacting me via text message to offer additional programs or opportunities that may be of interest to me and my family, for marketing purposes, updates and alerts, and to solicit feedback. I understand that the frequency of these text messages may vary, and that standard message and data costs may apply. Reply HELP for help and STOP to end. View our <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>."
                             values={{
                               tos: (chunks: any) => (
                                 <a


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

Received feedback from Sales message that we need to remove the affiliate language for SMS carrier approval.

- Fixes https://linear.app/myfriendben/issue/MFB-215/central-more-sms-consent-issues

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Updated default text

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run:
- Configuration updates needed:
- Environment variables/settings to add:
- Manual testing steps:

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script:
- Update production config:
- Admin updates needed:
- Notify team/users of:

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
- Future considerations:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Urgent Need banner with “Learn more” linking to specific need cards.
  - Admin-only viewer and JSON download for redacted Policy Engine data.
  - Support for a new “Savings” need/category and icon.

- UI/UX
  - Need cards auto-expand via URL anchors for easier navigation.
  - Program page action buttons standardized and more responsive.
  - Consent text updated to remove “and its affiliates.”

- Tests
  - Added tests for UrgentNeedBanner.

- Chores
  - Added JSON viewer dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->