### PR TITLE
Add IL to current benefits E2E test

### DIFF
--- a/tests/current-benefits.spec.ts
+++ b/tests/current-benefits.spec.ts
@@ -9,6 +9,7 @@ const whiteLabels = [
   { name: 'Colorado', path: 'co' },
   { name: 'Massachusetts', path: 'ma' },
   { name: 'Colorado Energy Calculators', path: 'co_energy_calculator' },
+  { name: 'Illinois', path: 'il' },
 ];
 
 test.describe('Current Benefits Pages Test', () => {


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes: https://linear.app/myfriendben/issue/MFB-252/il-add-white-label-to-current-benefits-page-e2e-test

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Add configuration for IL white label to current benefits E2E test

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Admin updates needed: Address any programs or urgent needs that have `[PLACEHOLDER]` as their `website_description`

## Summary by CodeRabbit

- Tests
  - Expanded automated coverage by adding Illinois to white-label scenarios, validating the /il/current-benefits page for placeholders and untranslated labels alongside existing states. Enhances reliability and consistency of state-specific benefits pages. No functional or UI changes; this strengthens regression protection for future updates. Release behavior remains unchanged for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->