### PR TITLE
Fix UTM parameter capture in Google Analytics

### DIFF
--- a/src/Components/CampaignAnalytics/useCampaign.tsx
+++ b/src/Components/CampaignAnalytics/useCampaign.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { setCampaign } from './campaign';
 import useUtmParameters from './useUtmParameters';
 
-// Pulls the utm parameters, saves, and removes from the URL
+// Reads UTM parameters from URL and saves to session storage
 export default function useCampaign() {
   const utmParameters = useUtmParameters();
   useEffect(() => {


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes [MFB-228](https://linear.app/myfriendben/issue/MFB-228/nc-utm-codes-not-displaying-in-google-analytics)

In my [original UTM parameter implementation](https://github.com/MyFriendBen/benefits-calculator/pull/1880) that stored UTM parameters in our database, I removed the UTM parameters from the url to ensure the url is clean for sharing and to try and keep the integrity of the campaign analytics. However, removing the UTM parameters from the url prevents google analytics from consistently capturing them. I tested this in my own instance of Google Analytics. You can also see this from comparing campaign numbers in GA and our database; I found 1 session with the campaign "lanternfall25" in GA, but 209 in the database.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Removed code that removed the utm parameters from the url.

Results:
- The utm_campaign query parameter is not removed on page load.
- The utm_campaign query parameter is removed when the user submits their language. This is because it is not included in the `useQueryString` url builder.

https://github.com/user-attachments/assets/b305ee3d-359d-44c5-a732-043fb5fd5d70

## Testing

<!-- Steps needed to test this PR locally -->

- Manual testing steps:
  - Add UTM parameters to the localhost url, for example `http://localhost:3000/ma/step-1?utm_campaign=mytest`. Ensure that when you go to that link, the utm parameters remain in the url.
  - Ensure the campaign value is still saved to the database in the screens table, after the screen is created in step 3.
  - If you have access to google analytics, you can use the network tab to test that utm parameters are included in the /g/collect requests.

## Deployment

<!-- Steps needed AFTER merging to get this live -->

None

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations: I considered more complex ways to continue removing utm parameters from the url and still get the utm parameters to Google Analytics. However, I did not find a clean approach for this and opted for simple here. I don't think it's a problem to leave the utm parameters, and they are removed after the language select anyways.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Visiting links with UTM parameters no longer triggers automatic URL changes or redirects.
  * The address bar now preserves original UTM parameters, improving shareability and consistency across sessions.
  * Eliminates unexpected page refreshes or flicker caused by navigation updates during page load.
  * Improves reliability of back/forward navigation by avoiding silent URL modifications.
  * Provides a smoother browsing experience with stable, predictable URLs when viewing campaign-related pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->