### PR TITLE
Add IL: LIHEAP current benefit support

### DIFF
--- a/src/Assets/updateFormData.tsx
+++ b/src/Assets/updateFormData.tsx
@@ -40,6 +40,7 @@ export function useUpdateFormData() {
         il_ctc: response.has_il_ctc ?? false,
         il_transit_reduced_fare: response.has_il_transit_reduced_fare ?? false,
         il_bap: response.has_il_bap ?? false,
+        il_liheap: response.has_il_liheap ?? false,
         lifeline: response.has_lifeline ?? false,
         leap: response.has_leap ?? false,
         nc_lieap: response.has_nc_lieap ?? false,

--- a/src/Assets/updateScreen.ts
+++ b/src/Assets/updateScreen.ts
@@ -55,6 +55,7 @@ const getScreensBody = (formData: FormData, languageCode: Language, whiteLabel: 
     has_erc: null,
     has_lifeline: formData.benefits.lifeline ?? null,
     has_leap: formData.benefits.leap ?? null,
+    has_il_liheap: formData.benefits.il_liheap ?? null,
     has_mydenver: formData.benefits.mydenver ?? null,
     has_nslp: formData.benefits.nslp ?? null,
     has_oap: formData.benefits.oap ?? null,

--- a/src/Types/ApiFormData.ts
+++ b/src/Types/ApiFormData.ts
@@ -178,6 +178,7 @@ export type ApiFormData = {
   has_ede: boolean | null;
   has_erc: boolean | null;
   has_leap: boolean | null;
+  has_il_liheap: boolean | null;
   has_nc_lieap: boolean | null;
   has_nccip: boolean | null;
   has_oap: boolean | null;


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

Add support for IL: LIHEAP as a current benefit, so that users can indicate that they already have it and not see it in their results.

- Fixes: https://linear.app/myfriendben/issue/MFB-250/il-add-low-income-home-energy-assistance-program-liheap
- Related PR: https://github.com/MyFriendBen/benefits-api/pull/1181

## Changes Made

- Add `il_liheap` / `has_il_liheap` to update functions and `apiFormData` type so it is handled in requests/responses to the benefits API

<img width="1052" height="183" alt="Screenshot 2025-10-07 at 9 24 57 AM" src="https://github.com/user-attachments/assets/7c4e5152-8df4-4721-aad9-b9a7089a4f5e" />

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: See related PR
- Configuration updates needed: See related PR
- Environment variables/settings to add: None
- Manual testing steps:
    * Create a screen eligible for LIHEAP in the IL whitelabel (see related PR for details)
    * On step 8, select "Yes" for "Does your household currently have any benefits?"
    * Under "Housing and Utilities", select "Low Income Home Energy Assistance Program (LIHEAP)"
    * On step 12, verify that LIHEAP is listed under "Current Benefits"
    * On the results page, verify that LIHEAP is not present

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script: N/A
- Update production config: N/A
- Admin updates needed: N/A

## Summary by CodeRabbit

- New Features
  - Added an Illinois LIHEAP option to the benefits section of the form, allowing users to indicate participation.
  - The selected value is saved with your application data and included in updates sent to the server.
  - Defaults to “not selected” unless chosen, ensuring a clear opt-in.
  - Improves consistency of benefits information across screens without changing existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->