### PR TITLE
MFB-349: Use placeholder instead of default value of 0 for HH Size Step 4

### DIFF
--- a/src/Components/Steps/HouseholdSize.tsx
+++ b/src/Components/Steps/HouseholdSize.tsx
@@ -51,7 +51,7 @@ const HouseholdSize = () => {
   } = useStepForm<FormSchema>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      householdSize: formData.householdSize ?? 0,
+      householdSize: formData.householdSize || undefined,
     },
     questionName: 'householdSize',
     onSubmitSuccessfulOverride: nextStep,


### PR DESCRIPTION
## Context & Motivation

This is just a slight enhancement to improve user experience. User no longer has to delete the default "0" before entering a valid HH size on step 4. Use a placeholder instead. 

- Fixes [#349](https://linear.app/myfriendben/issue/MFB-349/change-default-hh-size-from-0-to-household-size-placeholder)
- Related PR: N/A

## Changes Made

- Updated the default to `undefined` instead of `0` in benefits-calculator/src/Components/Steps/HouseholdSize.tsx

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: N/A
- Configuration updates needed: N/A
- Environment variables/settings to add: N/A
- Manual testing steps:
    - See expected behavior screenshots in the ticket [#349](https://linear.app/myfriendben/issue/MFB-349/change-default-hh-size-from-0-to-household-size-placeholder) 
    - Run `npm install`
    - Run `npm run dev`    
    - Test Standard Screener
        - Visit http://localhost:3000/
        - Fill out screener until step 4
        - Confirm instead of "0" showing the text box, "Household Size" is showing
        - Confirm when you click the text box to enter text, it clears the placeholder and allows you to directly enter a number without deleting anything
        - Confirm when you clear the text box, it does not let you continue to the next page
        - Confirm it only allows numbers 1-8 inclusive
    - CESN
        - Visit http://localhost:3000/co_energy_calculator/landing-page
        - Fill out screener until step 4
        - Confirm instead of "0" showing the text box, "Household Size" is showing
        - Confirm when you click the text box to enter text, it clears the placeholder and allows you to directly enter a number without deleting anything
        - Confirm when you clear the text box, it does not let you continue to the next page
        - Confirm it only allows numbers 1-8 inclusive

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script: N/A
- Update production config: N/A
- Admin updates needed: N/A
- Notify team/users of: N/A

## Notes for Reviewers

- Known limitations: N/A
- Future considerations: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Household size field no longer auto-fills with 0 when no prior value exists. The field now starts blank, prompting explicit user entry and preventing accidental zero submissions. Validation and helper messages correctly reflect an empty state, improving clarity throughout the form. This leads to more accurate data collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->