### PR TITLE
Central: Modify immigration filter language

### DIFF
--- a/src/Components/QuestionComponentContainer/QuestionComponentContainer.css
+++ b/src/Components/QuestionComponentContainer/QuestionComponentContainer.css
@@ -33,7 +33,7 @@ p {
   font-family: 'Open Sans', serif;
 }
 
-.help-text {
+.help-text, .MuiTypography-root.help-text  {
   font-family: 'Open Sans', serif;
   font-size: 1rem;
   font-weight: 200;

--- a/src/Components/Results/Programs/Filter.tsx
+++ b/src/Components/Results/Programs/Filter.tsx
@@ -15,6 +15,7 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
 import './Filter.css';
+import '../../QuestionComponentContainer/QuestionComponentContainer.css';
 import { Context } from '../../Wrapper/Wrapper';
 
 export const Filter = () => {
@@ -255,13 +256,7 @@ export const Filter = () => {
         <FormattedMessage id="filterSection.header" defaultMessage="Filter Results by Citizenship" />
       </h2>
       <div className="filter-description">
-        <Typography variant="body2" color="text.secondary" sx={{
-          fontFamily: "'Open Sans', serif",
-          fontSize: '1rem',
-          fontWeight: 200,
-          color: 'black',
-          marginBottom: '1rem',
-        }}>
+        <Typography variant="body2" color="text.secondary" className="help-text">
           <FormattedMessage
             id="filterSection.citizenHelpText"
             defaultMessage="Household members may have mixed immigration status. This means that some people in your home may qualify for benefits even if others do not. Use this filter to see how a person's status affects their ability to qualify. If you sign up for a public benefit or file a tax return, your family’s information may be shared with immigration officials."


### PR DESCRIPTION
## Context & Motivation
- Fixes #[MFB-344](https://linear.app/myfriendben/issue/MFB-344/central-modify-immigration-filter-language)

## Changes Made
<img width="1314" height="900" alt="image" src="https://github.com/user-attachments/assets/00b32ceb-16e8-4afb-828b-efa913e3e6fe" />

- change text for immigration filters, move from hint to static on the results page under the line "Filter Results Citizenship"

- Admin updates needed: 
`filterSection.citizenHelpText` -  "Household members may have mixed immigration status. This means that some people in your home may qualify for benefits even if others do not. Use this filter to see how a person's status affects their ability to qualify. If you sign up for a public benefit or file a tax return, your family’s information may be shared with immigration officials."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-context citizenship help description to the Programs filter, clarifying that family information may be shared with immigration officials.

* **Style**
  * Separated the header from the help text and applied consistent typography for improved readability and visual hierarchy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->