### PR TITLE
MFB-345: delete unused keys from icon map

### DIFF
--- a/src/Components/Results/helpers.ts
+++ b/src/Components/Results/helpers.ts
@@ -27,7 +27,7 @@ import { ReactComponent as Resources } from '../../Assets/icons/General/resource
  * List of lucide-based icon names that require special styling (white fill with colored stroke)
  * Used across CategoryHeading and ProgramPage components
  */
-export const LUCIDE_ICONS = ['house_plug', 'light_bulb', 'talk', 'air_vent', 'coin', 'heart_hand', 'lightning', 'triangle_alert', 'heat', 'low_fuel'];
+export const LUCIDE_ICONS = ['house_plug', 'light_bulb', 'talk', 'air_vent', 'coin', 'heart_hand', 'lightning', 'triangle_alert'];
 
 /**
  * Mapping of icon keys (from API/backend) to their corresponding React SVG components
@@ -45,7 +45,6 @@ export const ICON_OPTIONS_MAP: Record<string, ComponentType<SVGProps<SVGSVGEleme
   family_planning: FamilyPlanning,
   food: Food,
   food_groceries: Food,
-  heat: HeartHand, //TODO: Delete once PR#1947 deployed
   health_care: HealthCare,
   heart_hand: HeartHand,
   housing: Residence,
@@ -53,7 +52,6 @@ export const ICON_OPTIONS_MAP: Record<string, ComponentType<SVGProps<SVGSVGEleme
   legal_services: LegalServices,
   light_bulb: LightBulb,
   lightning: Lightning,
-  low_fuel: TriangleAlert, //TODO: Delete once PR#1947 deployed
   managing_housing: Housing,
   savings: Resources,
   talk: Talk,


### PR DESCRIPTION
## Context & Motivation

This just removes some icon references that were needed before deploying https://github.com/MyFriendBen/benefits-calculator/pull/1947

- Fixes (https://linear.app/myfriendben/issue/MFB-345/cesn-update-iconography)
- Related PR: https://github.com/MyFriendBen/benefits-calculator/pull/1947

## Changes Made

Delete two key-value pairs in `ICON_OPTIONS_MAP`

## Testing

- Migrations to run: N/A
- Configuration updates needed: N/A
- Environment variables/settings to add: N/A
- Manual testing steps: Go through CESN and ensure that the icons on the results page look like this: 
<img width="489" height="90" alt="image" src="https://github.com/user-attachments/assets/17e33a52-9a0c-4ed5-8487-685ee5237838" />
<img width="366" height="60" alt="image" src="https://github.com/user-attachments/assets/830cbb2d-f8c8-433d-aa0a-e2b7ad7dc336" />
<img width="374" height="50" alt="image" src="https://github.com/user-attachments/assets/81753aef-c60e-48a9-8323-f09b3bd7e325" />
<img width="435" height="50" alt="image" src="https://github.com/user-attachments/assets/120b2c90-9e0a-4fd7-aa12-aad2d518fb76" />
<img width="1024" height="113" alt="image" src="https://github.com/user-attachments/assets/36b3ef8a-6632-48a4-af6f-3fbd00286c73" />

## Deployment

- Run script: N/A
- Update production config: N/A
- Admin updates needed: N/A
- Notify team/users of: N/A

## Notes for Reviewers

- Known limitations:
- Future considerations:
