### PR TITLE
MFB-345: fix icons for current benefits page

### DIFF
--- a/src/Components/CurrentBenefits/CurrentBenefits.tsx
+++ b/src/Components/CurrentBenefits/CurrentBenefits.tsx
@@ -11,7 +11,7 @@ import { useTranslateNumber } from '../../Assets/languageOptions';
 import { useParams } from 'react-router-dom';
 import { useConfig } from '../Config/configHook';
 import { FormattedMessageType } from '../../Types/Questions';
-import { ICON_OPTIONS_MAP } from '../Results/helpers';
+import { ICON_OPTIONS_MAP, LUCIDE_ICONS } from '../Results/helpers';
 
 export const iconCategoryMap: Record<string, ComponentType<SVGProps<SVGSVGElement>>> = {
   default: ICON_OPTIONS_MAP['cash'],
@@ -130,11 +130,14 @@ const CurrentBenefits = () => {
         CategoryIcon = iconCategoryMap['default'];
       }
 
+      const isLucideIcon = LUCIDE_ICONS.includes(icon.toLowerCase());
+      const iconClassName = isLucideIcon ? 'category-heading-icon category-lucide-icon' : 'category-heading-icon';
+
       return (
         <div key={index} className="category-section-container">
           <div className="category-heading-column">
             <div
-              className="category-heading-icon"
+              className={iconClassName}
               aria-label={intl.formatMessage({
                 id: name.label,
                 defaultMessage: name.default_message,


### PR DESCRIPTION
## Context & Motivation

Icons were not showing correctly on current benefits page

- Fixes https://linear.app/myfriendben/issue/MFB-345/cesn-update-iconography
- Related PR: https://github.com/MyFriendBen/benefits-calculator/pull/1947

## Changes Made

  * Improved icon rendering in the current benefits section with enhanced styling support for consistent visual presentation across different icon types and interface elements.

## Testing

- Migrations to run: N/A
- Configuration updates needed: N/A
- Environment variables/settings to add: N/A
- Manual testing steps: Go to http://localhost:3000/co_energy_calculator/current-benefits and make sure all the icons are similar size to the text and filled with white (not red)
-

## Deployment

- Run script: N/A
- Update production config: N/A
- Admin updates needed: N/A
- Notify team/users of: Notify Debra and Manali everything should be ready to go

## Notes for Reviewers

- Known limitations:
- Future considerations:

