### PR TITLE
Add Github workflow for tests and coverage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,6 +31,3 @@ jobs:
         with:
           eslint: true
           prettier: true
-
-      - name: Run unit tests
-        run: npm test -- --coverage --watchAll=false --passWithNoTests

--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -1,0 +1,33 @@
+name: Tests & Coverage
+
+on:
+  pull_request:
+    branches: [ dev, main ]
+
+jobs:
+  test-and-upload-coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test -- --coverage --watchAll=false --passWithNoTests
+
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

Improves CI/CD pipeline organization by separating concerns between linting/testing workflows and uploads coverage to CodeCov

- Fixes: https://linear.app/myfriendben/issue/MFB-397/add-workflow-to-run-fe-unit-tests-and-upload-coverage
- Related PR: https://github.com/MyFriendBen/benefits-api/pull/1199

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Added `.github/workflows/tests-and-coverage.yml` - Dedicated workflow for running unit tests and uploading coverage to Codecov
- Modified `.github/workflows/lint.yml` - Removed unit testing step (lines 35-36) to focus solely on linting

<img width="2543" height="1272" alt="Screenshot 2025-10-21 at 4 10 30 PM" src="https://github.com/user-attachments/assets/ef894d80-077d-4a06-b7fa-2067ce153c6f" />

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
    * Our E2E tests generate reports, but I made the decision not to include them in our coverage reporting. Open to feedback, but IMO they might inflate our numbers in a way that isn't impactful.