### PR TITLE
MFB-411: Edit language for value format

### DIFF
--- a/src/Components/Results/FormattedValue.tsx
+++ b/src/Components/Results/FormattedValue.tsx
@@ -129,17 +129,12 @@ function useValueFormats(): DefaultMap<(program: Program) => string> {
     },
     lump_sum: (program: Program) => {
       return (
-        intl.formatMessage({ id: 'results.programs.values.formats.lump_sum', defaultMessage: 'One-time payment of ' }) +
         translateNumber(formatToUSD(programValue(program)))
       );
     },
     estimated_annual: (program: Program) => {
-      return (
-        intl.formatMessage({
-          id: 'results.programs.values.formats.estimated_annual',
-          defaultMessage: 'Average annual savings of ',
-        }) + translateNumber(formatToUSD(programValue(program)))
-      );
+      const perYear = intl.formatMessage({ id: 'results.programs.values.formats.per_year', defaultMessage: '/year' });
+      return translateNumber(formatToUSD(programValue(program))) + perYear;
     },
   };
 }


### PR DESCRIPTION
## Context & Motivation

Update how we specify on the results page annual and one-time payments

- Fixes https://linear.app/myfriendben/issue/MFB-409/update-vehical-exchange-colorado-value-format

## Changes Made

In the "Estimated Savings" column on the results page, changed it to be more in line with our "/month" indicator and to generally make it simpler and cleaner: 

- "One-time payment of " -> removed this
- "Average annual savings of" -> "/year"

## Testing

- Migrations to run: N/A
- Configuration updates needed: N/A
- Environment variables/settings to add: N/A
- Manual testing steps: Go through the CESN screener and get to the results page - should see a mix of "/month", "/year", and for one-time payment programs, nothing

Before: 
<img width="1310" height="430" alt="image" src="https://github.com/user-attachments/assets/5cefc9c4-85bd-4643-bc07-6e55090e267e" />

After: 
<img width="1310" height="279" alt="image" src="https://github.com/user-attachments/assets/0a7fa92c-0bf9-4e3d-8b56-26d265b745e3" />


## Deployment


- Run script: N/A
- Update production config: N/A
- Admin updates needed: Add translation for results.programs.values.formats.per_year

@catonph added this to staging and prod already

- Notify team/users of: N/A

## Notes for Reviewers


- Known limitations:
- Future considerations:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified lump sum payment display to show only currency-formatted amounts without prefix text.
  * Updated annual savings display format to use a per-year suffix indicator, replacing the previous descriptive prefix approach for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->