### PR TITLE
Fix MedicareSavingsNC so it doesn't appear if existing ACA or Medicaid

### DIFF
--- a/src/Assets/updateFormData.tsx
+++ b/src/Assets/updateFormData.tsx
@@ -69,6 +69,7 @@ export function useUpdateFormData() {
         csfp: response.has_csfp ?? false,
         ccdf: response.has_ccdf ?? false,
         aca: response.has_aca ?? false,
+        nc_medicare_savings: response.has_nc_medicare_savings ?? false,
         ma_eaedc: response.has_ma_eaedc ?? false,
         ma_ssp: response.has_ma_ssp ?? false,
         ma_mbta: response.has_ma_mbta ?? false,

--- a/src/Assets/updateScreen.ts
+++ b/src/Assets/updateScreen.ts
@@ -76,6 +76,7 @@ const getScreensBody = (formData: FormData, languageCode: Language, whiteLabel: 
     has_section_8: formData.benefits.section_8 ?? null,
     has_chp: formData.benefits.chp ?? null,
     has_medicaid: formData.benefits.medicaid ?? null,
+    has_nc_medicare_savings: formData.benefits.nc_medicare_savings ?? null,
     has_nc_lieap: formData.benefits.nc_lieap ?? null,
     has_ncwap: formData.benefits.ncwap ?? null,
     has_nccip: formData.benefits.nccip ?? null,

--- a/src/Types/ApiFormData.ts
+++ b/src/Types/ApiFormData.ts
@@ -210,6 +210,7 @@ export type ApiFormData = {
   has_private_hi?: boolean | null;
   has_medicaid_hi?: boolean | null;
   has_medicare_hi?: boolean | null;
+  has_nc_medicare_savings?: boolean | null;
   has_chp_hi?: boolean | null;
   has_no_hi?: boolean | null;
   needs_food: boolean | null;


### PR DESCRIPTION
## Context & Motivation

- Fixes #[MFB-414](https://linear.app/myfriendben/issue/MFB-414/fix-medicaresavingsnc-so-it-doesnt-appear-if-existing-aca-or-medicaid)
- Related PR: [1230] (https://github.com/MyFriendBen/benefits-api/pull/1230)

## Changes Made

- fix bug

## Testing
- Manual testing steps:
       1. Fill out a screener that is eligible for MedicareSavingsNC
        2. Select ACA or Medicaid in step 10


