### PR TITLE
MFB-118: FE update current benefits question wording

### DIFF
--- a/src/Components/Steps/AlreadyHasBenefits.tsx
+++ b/src/Components/Steps/AlreadyHasBenefits.tsx
@@ -195,7 +195,7 @@ function AlreadyHasBenefits() {
                 {...field}
                 aria-label={formatMessage({
                   id: 'questions.hasBenefits',
-                  defaultMessage: 'Does your household currently have any benefits?',
+                  defaultMessage: 'Does anyone in your household currently have public assistance benefits?',
                 })}
                 sx={{ marginBottom: '1rem' }}
               >


### PR DESCRIPTION
## Context & Motivation

CESN requested this change and after taking to wider team, we all agreed we liked it better than existing copy. 

- Fixes: https://linear.app/myfriendben/issue/MFB-118/cesn-change-copy-in-step-10
- Related PR: BE PR https://github.com/MyFriendBen/benefits-api/pull/1243

## Changes Made

Change copy for asking if HH has existing benefits

## Testing

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:
    - Run FE locally
    - Get to step 8 of CO screener
    - Confirm it says Does anyone in your household currently have public assistance benefits?
    - Repeat with CESN 

## Deployment

- Run script: None
- Update production config: None
- Admin updates needed: None
- Notify team/users of: None

## Notes for Reviewers

- Known limitations:
- Future considerations:
