### PR TITLE
MFB-118 fix: use override translation component

### DIFF
--- a/src/Components/Steps/AlreadyHasBenefits.tsx
+++ b/src/Components/Steps/AlreadyHasBenefits.tsx
@@ -162,7 +162,7 @@ function AlreadyHasBenefits() {
   const renderHelpSection = () => {
     return (
       <HelpButton>
-        <FormattedMessage
+        <OverrideableTranslation
           id="questions.hasBenefits-description"
           defaultMessage="This information will help make sure we don't give you results for benefits you already have."
         />


### PR DESCRIPTION
## Context & Motivation

Need the text to be overriden for CESN and otherwise the default

- Fixes https://linear.app/myfriendben/issue/MFB-118/cesn-change-copy-in-step-10

## Changes Made

Make questions.hasBenefits-description an OverrideableTranslation

## Testing

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings that were already added / updated:
    - `questions.hasBenefits` → "Does anyone in your household currently have public assistance benefits?"
    - `questions.hasBenefits-description` → "This information will help make sure we don't give you results for benefits you already have."
    - `energyCalculator.hasBenefits.description` → "You may qualify for some energy programs if someone in your household receives public benefits (for example, SNAP, Medicaid, etc.)."
- Manual testing steps:
    - In CESN, check that Step 10 looks like this: 
<img width="1346" height="455" alt="image" src="https://github.com/user-attachments/assets/1b4f7a08-dfa5-4d40-8766-1392afdaec73" />
    - In non-CESN, screener, ensure it looks like: 
 
<img width="1003" height="427" alt="image" src="https://github.com/user-attachments/assets/6de99791-0a52-44bf-8e3b-55dd19aea02b" />


## Deployment

- Run script: None
- Update production config: None
- Admin updates needed:
    - `questions.hasBenefits` → "Does anyone in your household currently have public assistance benefits?"
    - `questions.hasBenefits-description` → "This information will help make sure we don't give you results for benefits you already have."
    - `energyCalculator.hasBenefits.description` → "You may qualify for some energy programs if someone in your household receives public benefits (for example, SNAP, Medicaid, etc.)."
- Notify team/users of: None

## Notes for Reviewers

- Known limitations:
- Future considerations:
