### PR TITLE
MFB-421: temporarily remove rebate calculators

### DIFF
--- a/src/Components/EnergyCalculator/Results/RebatePage.tsx
+++ b/src/Components/EnergyCalculator/Results/RebatePage.tsx
@@ -117,8 +117,7 @@ function RebateCard({ rebate, rebateCategory }: RebateProps) {
 
         <EnergyCalculatorRebateCalculator rebate={rebate} />
 
-        The calculator only appeared for 'percent' and 'dollar_amount' rebate types
-        (not for 'dollars_per_unit' types as noted in RebatePageMappings.tsx:405-406)
+        Remains in code as CDS wanted the option to reintroduce it easily
       */}
       <div className="energy-calculator-rebate-page-more-info">
         <TrackedOutboundLink

--- a/src/Components/EnergyCalculator/Results/RebatePageMappings.tsx
+++ b/src/Components/EnergyCalculator/Results/RebatePageMappings.tsx
@@ -395,6 +395,7 @@ function staticAmountSavingCalculatorGenerator(amount: number, maxAmount: number
  *
  * TEMPORARILY REMOVED FROM UI (at CDS partner request)
  * Previously displayed in: src/Components/EnergyCalculator/Results/RebatePage.tsx:111
+ * Remains in code as CDS wanted the option to reintroduce it easily
  */
 export function EnergyCalculatorRebateCalculator({ rebate }: RebateComponentProps) {
   const [cost, setCost] = useState(0);


### PR DESCRIPTION
## Context & Motivation

CDS requested we remove (possibly temporarily) the interactive rebate calculators from the rebate results

- Fixes https://linear.app/myfriendben/issue/MFB-421/cesn-remove-estimated-value-calculator-from-rebate-results

## Changes Made

- Comment out the calculator in the `RebateCard` component with detailed note
- Comment where `EnergyCalculatorRebateCalculator` is defined to explain why not currently in use but still in code base

## Testing

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps: 
    - Run FE locally
    - Go to results and "More info" for one of the rebates
    - Should no longer show calculators:
<img width="1051" height="509" alt="image" src="https://github.com/user-attachments/assets/5595972c-5912-4f40-8e43-61421cc5212a" />


## Deployment

- Run script: None
- Update production config: None
- Admin updates needed: None
- Notify team/users of: Notify CDS

## Notes for Reviewers

- Known limitations:
- Future considerations:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The interactive rebate calculator feature has been temporarily disabled and is no longer visible on the rebate results page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->