### PR TITLE
Add Texas to current benefits E2E tests

### DIFF
--- a/tests/current-benefits.spec.ts
+++ b/tests/current-benefits.spec.ts
@@ -10,6 +10,7 @@ const whiteLabels = [
   { name: 'Massachusetts', path: 'ma' },
   { name: 'Colorado Energy Calculators', path: 'co_energy_calculator' },
   { name: 'Illinois', path: 'il' },
+  { name: 'Texas', path: 'tx' },
 ];
 
 test.describe('Current Benefits Pages Test', () => {


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

This change adds TX to our E2E test that checks that there are no `[PLACEHOLDER]` values on a white label's current benefits page.

- Fixes: [MFB-418](https://linear.app/myfriendben/issue/MFB-418/add-tx-website-descriptions)

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Add TX to `whiteLabels` config in `tests/current-benefits.spec.ts`

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

There were a few TX programs where I missed including `website_description` in their initial program config. ~I added the missing descriptions in prod via the admin UI, but this E2E test (that runs against staging) will fail until the prod translations are imported from prod to staging during tomorrow's (11/19/2025) deploy.~ Update: the E2E tests are passing now that the translations have been imported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to include additional regional test scenarios, enhancing quality assurance verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->