### PR TITLE
Add MA: Head Start

### DIFF
--- a/src/Assets/updateFormData.tsx
+++ b/src/Assets/updateFormData.tsx
@@ -75,6 +75,7 @@ export function useUpdateFormData() {
         ma_mbta: response.has_ma_mbta ?? false,
         ma_maeitc: response.has_ma_maeitc ?? false,
         ma_macfc: response.has_ma_macfc ?? false,
+        head_start: response.has_head_start ?? false,
         co_andso: response.has_co_andso ?? false,
         co_care: response.has_co_care ?? false,
         project_cope: response.has_project_cope ?? false,

--- a/src/Assets/updateScreen.ts
+++ b/src/Assets/updateScreen.ts
@@ -88,6 +88,7 @@ const getScreensBody = (formData: FormData, languageCode: Language, whiteLabel: 
     has_ma_mbta: formData.benefits.ma_mbta ?? null,
     has_ma_maeitc: formData.benefits.ma_maeitc ?? null,
     has_ma_macfc: formData.benefits.ma_macfc ?? null,
+    has_head_start: formData.benefits.head_start ?? null,
     has_co_andso: formData.benefits.co_andso ?? null,
     has_co_care: formData.benefits.co_care ?? null,
     has_project_cope: formData.benefits.project_cope ?? null,

--- a/src/Types/ApiFormData.ts
+++ b/src/Types/ApiFormData.ts
@@ -200,6 +200,7 @@ export type ApiFormData = {
   has_ma_mbta: boolean | null;
   has_ma_maeitc: boolean | null;
   has_ma_macfc: boolean | null;
+  has_head_start: boolean | null;
   has_co_andso: boolean | null;
   has_co_care: boolean | null;
   has_project_cope: boolean | null;


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes: [MFB-270](https://linear.app/myfriendben/issue/MFB-270/ma-add-head-startearly-head-start)
- Related PR: https://github.com/MyFriendBen/benefits-api/pull/1269

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Add `head_start` field to form data and update related functions

<img width="1002" height="159" alt="Screenshot 2025-12-04 at 10 13 40 AM" src="https://github.com/user-attachments/assets/0c997e4f-53ce-4595-b34e-56862bbf2b52" />

## Testing

<!-- Steps needed to test this PR locally -->

See related PR for BE setup required for testing.

1. Visit the Current Household Benefits step of the screener in the MA white label
2. Select Head Start as a current benefit
3. Visit the Confirm Information step
4. Verify that you see Head Start listed as a Current Household Benefit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new "head start" field across the app: the value is now tracked in form data, included in form updates, and sent to the backend. Sensible defaults and null handling are applied to preserve compatibility and avoid breaking existing flows. This ensures screens, form persistence, and API payloads consistently reflect the new field.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->