### PR TITLE
Add MA: Early Head Start

### DIFF
--- a/src/Assets/updateFormData.tsx
+++ b/src/Assets/updateFormData.tsx
@@ -76,6 +76,7 @@ export function useUpdateFormData() {
         ma_maeitc: response.has_ma_maeitc ?? false,
         ma_macfc: response.has_ma_macfc ?? false,
         head_start: response.has_head_start ?? false,
+        early_head_start: response.has_early_head_start ?? false,
         co_andso: response.has_co_andso ?? false,
         co_care: response.has_co_care ?? false,
         project_cope: response.has_project_cope ?? false,

--- a/src/Assets/updateScreen.ts
+++ b/src/Assets/updateScreen.ts
@@ -89,6 +89,7 @@ const getScreensBody = (formData: FormData, languageCode: Language, whiteLabel: 
     has_ma_maeitc: formData.benefits.ma_maeitc ?? null,
     has_ma_macfc: formData.benefits.ma_macfc ?? null,
     has_head_start: formData.benefits.head_start ?? null,
+    has_early_head_start: formData.benefits.early_head_start ?? null,
     has_co_andso: formData.benefits.co_andso ?? null,
     has_co_care: formData.benefits.co_care ?? null,
     has_project_cope: formData.benefits.project_cope ?? null,

--- a/src/Types/ApiFormData.ts
+++ b/src/Types/ApiFormData.ts
@@ -201,6 +201,7 @@ export type ApiFormData = {
   has_ma_maeitc: boolean | null;
   has_ma_macfc: boolean | null;
   has_head_start: boolean | null;
+  has_early_head_start: boolean | null;
   has_co_andso: boolean | null;
   has_co_care: boolean | null;
   has_project_cope: boolean | null;


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes: [MFB-270](https://linear.app/myfriendben/issue/MFB-270/ma-add-head-startearly-head-start)
- Related PR: https://github.com/MyFriendBen/benefits-api/pull/1271

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Add `early_head_start` field to form data and update related functions

## Testing

<!-- Steps needed to test this PR locally -->

See related PR for BE setup required for testing.

1. Visit the Current Household Benefits step of the screener in the MA white label
2. Select Early Head Start as a current benefit
3. Visit the Confirm Information step
4. Verify that you see Early Head Start listed as a Current Household Benefit



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Early Head Start benefit tracking—the app now captures this boolean benefit and includes it in data sent to the API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->