### PR TITLE
CESN: Match order of results header tiles and results order logic

### DIFF
--- a/src/Components/EnergyCalculator/Results/ResultsHeader.tsx
+++ b/src/Components/EnergyCalculator/Results/ResultsHeader.tsx
@@ -3,13 +3,34 @@ import { useContext } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useResultsContext } from '../../Results/Results';
 import { Context } from '../../Wrapper/Wrapper';
+import { useEnergyCalculatorNeedsRebates } from './RebateCategories';
 import './ResultsHeader.css';
 
 export default function EnergyCalculatorResultsHeader() {
   const { theme } = useContext(Context);
   const { programs, energyCalculatorRebateCategories } = useResultsContext();
+  const needsRebates = useEnergyCalculatorNeedsRebates();
 
   const rebateCount = energyCalculatorRebateCategories.reduce((acc, category) => acc + category.rebates.length, 0);
+
+  const programsTile = (
+    <section className="energy-calculator-results-header-programs-count-text">
+      <div className="energy-calculator-results-header-programs-count">{programs.length}</div>
+      <div>
+        <FormattedMessage id="energyCalculator.results.header.programsFound" defaultMessage="Programs Found" />
+      </div>
+    </section>
+  );
+
+  const rebatesTile =
+    rebateCount > 0 ? (
+      <section className="energy-calculator-results-header-programs-count-text">
+        <div className="energy-calculator-results-header-programs-count">{rebateCount}</div>
+        <div>
+          <FormattedMessage id="energyCalculator.results.header.rebatesFound" defaultMessage="Rebates Found" />
+        </div>
+      </section>
+    ) : null;
 
   return (
     <CardContent
@@ -23,19 +44,16 @@ export default function EnergyCalculatorResultsHeader() {
       }}
     >
       <header className="energy-calculator-results-header">
-        <section className="energy-calculator-results-header-programs-count-text">
-          <div className="energy-calculator-results-header-programs-count">{programs.length}</div>
-          <div>
-            <FormattedMessage id="energyCalculator.results.header.programsFound" defaultMessage="Programs Found" />
-          </div>
-        </section>
-        {rebateCount > 0 && (
-          <section className="energy-calculator-results-header-programs-count-text">
-            <div className="energy-calculator-results-header-programs-count">{rebateCount}</div>
-            <div>
-              <FormattedMessage id="energyCalculator.results.header.rebatesFound" defaultMessage="Rebates Found" />
-            </div>
-          </section>
+        {needsRebates ? (
+          <>
+            {rebatesTile}
+            {programsTile}
+          </>
+        ) : (
+          <>
+            {programsTile}
+            {rebatesTile}
+          </>
         )}
       </header>
     </CardContent>


### PR DESCRIPTION
## Context & Motivation

- Fixes [MFB-484](https://linear.app/myfriendben/issue/MFB-484/cesn-order-of-results-header-tiles-matches-results-order-logic)
- CESN results header tiles ("X Programs Found", "X Rebates Found") always showed programs first, even when rebates appeared first on the results page

## Changes Made

- Updated `ResultsHeader.tsx` to use `useEnergyCalculatorNeedsRebates()` hook
- Header tiles now render in same order as results categories

## Testing

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:
  - **Rebates First:** In CESN screener, answer No to past due bills/disconnected electricity, Yes to needing HVAC/stove/water heater → header shows "Rebates Found" before "Programs Found"
  - **Programs First:** Answer Yes to past due bills OR No to all appliance questions → header shows "Programs Found" before "Rebates Found"

## Deployment

- Run script: None
- Update production config: None
- Admin updates needed: None
- Notify team/users of: None

## Notes for Reviewers

- Known limitations: None
- Future considerations: None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Results header now shows two summary tiles: Programs Found and Rebates Found.
  * Rebates tile is shown only when rebates exist; tile ordering adapts based on rebate eligibility for clearer context.

* **Improvements**
  * Replaced previous inline header layout with modular tiles for consistent presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->