### PR TITLE
MFB-874: Add Texas to state selection dropdown on root route

### DIFF
--- a/src/Components/Steps/SelectStatePage.tsx
+++ b/src/Components/Steps/SelectStatePage.tsx
@@ -17,9 +17,10 @@ import { usePageTitle } from '../Common/usePageTitle';
 
 export const STATES: { [key: string]: string } = {
   co: 'Colorado',
-  nc: 'North Carolina',
-  ma: 'Massachusetts',
   il: 'Illinois',
+  ma: 'Massachusetts',
+  nc: 'North Carolina',
+  tx: 'Texas',
 };
 
 const SelectStatePage = () => {


### PR DESCRIPTION
## Context & Motivation

Fixes [MFB-874](https://linear.app/myfriendben/issue/MFB-874/add-texas-to-state-selection-dropdown-on-root-route)

Texas was missing from the state dropdown on the root `/` and `/select-state` routes. Users had to already know to navigate directly to `/tx` — they couldn't discover Texas from the global entry point.

## Changes Made

- Added `tx: 'Texas'` to the `STATES` object in `SelectStatePage.tsx`
- Sorted states alphabetically by name (Colorado, Illinois, Massachusetts, North Carolina, Texas)

## Testing

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:
  - Navigate to `/` or `/select-state`
  - Confirm Texas appears in the state dropdown
  - Select Texas and confirm routing to `/tx/step-2`
  - Confirm existing states (CO, IL, MA, NC) still appear and route correctly

## Deployment

- No post-deploy steps needed

## Notes for Reviewers

- No backend changes required — Texas is already fully configured (`TxConfigurationData`, `ALL_VALID_WHITE_LABELS`)