### PR TITLE
MFB-963: CESN UI Fixes

### DIFF
--- a/src/Components/EnergyCalculator/Banner/Banner.css
+++ b/src/Components/EnergyCalculator/Banner/Banner.css
@@ -21,7 +21,7 @@
 .cesn-official-banner-text {
   color: #ffffff;
   font-family: var(--font-body);
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
   display: inline-flex;
   align-items: center;
 }

--- a/src/Components/EnergyCalculator/Banner/Banner.css
+++ b/src/Components/EnergyCalculator/Banner/Banner.css
@@ -31,7 +31,7 @@
   border: none;
   color: #6fa8f5;
   font-family: var(--font-body);
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
   cursor: pointer;
   padding: 0;
   text-decoration: underline;

--- a/src/Components/EnergyCalculator/Footer/Footer.test.tsx
+++ b/src/Components/EnergyCalculator/Footer/Footer.test.tsx
@@ -42,7 +42,7 @@ describe('EnergyCalculatorFooter', () => {
   it('renders the accessibility statement link', () => {
     renderFooter();
     const link = screen.getByRole('link', { name: /accessibility statement/i });
-    expect(link).toHaveAttribute('href', 'https://www.colorado.gov/accessibility');
+    expect(link).toHaveAttribute('href', 'https://www.colorado.gov/accessibility-standards');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noreferrer');
   });

--- a/src/Components/EnergyCalculator/Footer/Footer.test.tsx
+++ b/src/Components/EnergyCalculator/Footer/Footer.test.tsx
@@ -42,7 +42,7 @@ describe('EnergyCalculatorFooter', () => {
   it('renders the accessibility statement link', () => {
     renderFooter();
     const link = screen.getByRole('link', { name: /accessibility statement/i });
-    expect(link).toHaveAttribute('href', 'https://www.colorado.gov/accessibility-standards');
+    expect(link).toHaveAttribute('href', 'https://co.colorado.gov/accessibility-standards');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noreferrer');
   });

--- a/src/Components/EnergyCalculator/Footer/Footer.tsx
+++ b/src/Components/EnergyCalculator/Footer/Footer.tsx
@@ -5,7 +5,7 @@ import '../../Footer/PoweredByFooter.css';
 import './Footer.css';
 import { renderLogoSource } from '../../Referrer/referrerDataInfo';
 
-const CESN_ACCESSIBILITY_URL = 'https://www.colorado.gov/accessibility';
+const CESN_ACCESSIBILITY_URL = 'https://www.colorado.gov/accessibility-standards';
 
 export default function EnergyCalculatorFooter() {
   const privacyPolicyLink = useLocalizedLink('privacy_policy');

--- a/src/Components/EnergyCalculator/Footer/Footer.tsx
+++ b/src/Components/EnergyCalculator/Footer/Footer.tsx
@@ -5,7 +5,7 @@ import '../../Footer/PoweredByFooter.css';
 import './Footer.css';
 import { renderLogoSource } from '../../Referrer/referrerDataInfo';
 
-const CESN_ACCESSIBILITY_URL = 'https://www.colorado.gov/accessibility-standards';
+const CESN_ACCESSIBILITY_URL = 'https://co.colorado.gov/accessibility-standards';
 
 export default function EnergyCalculatorFooter() {
   const privacyPolicyLink = useLocalizedLink('privacy_policy');


### PR DESCRIPTION
## Context & Motivation

- Fixes MFB-963: https://linear.app/myfriendben/issue/MFB-963/cesn-ui-fixes
- Two small UI fixes for the CESN banner and footer

## Changes Made

- Reduced font size of "An official website of the State of Colorado" banner text and "Here's how you know" toggle from `0.75rem` → `0.6875rem`
- Updated footer accessibility link URL to `https://co.colorado.gov/accessibility-standards`

## Testing

- Migrations to run: N/A
- Configuration updates needed: N/A
- Environment variables/settings to add: N/A
- Manual testing steps: Navigate to the CESN energy calculator, verify the banner text is slightly smaller and the Accessibility Statement footer link goes to the correct URL

## Deployment

- Run script: N/A
- Update production config: N/A
- Admin updates needed: N/A
- Notify team/users of: N/A

## Notes for Reviewers

- Known limitations: N/A
- Future considerations: N/A