### PR TITLE
Hide duplicate WL benefit keys on confirmation step

### DIFF
--- a/src/Components/Confirmation/ConfirmationSteps.tsx
+++ b/src/Components/Confirmation/ConfirmationSteps.tsx
@@ -11,6 +11,7 @@ import { ReactComponent as Referral } from '../../Assets/icons/General/referral.
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useTranslateNumber } from '../../Assets/languageOptions';
 import { FormattedMessageType, QuestionName } from '../../Types/Questions';
+import { HasBenefitsProgram } from '../../Types/ApiCalls';
 import { useConfig } from '../Config/configHook';
 import { useReferralOptions } from '../../hooks/useReferralOptions';
 import DefaultConfirmationHHData from './ConfirmationHouseholdData';
@@ -233,27 +234,30 @@ function HasBenefits() {
     // TODO(MFB-720): drop the lowercase coercion once the join-table migration ships.
     const programsByKey = new Map(hasBenefitsPrograms.map((p) => [p.name_abbreviated.toLowerCase(), p]));
 
-    return selectedKeys.map((key) => {
-      const program = programsByKey.get(key);
-      if (program) {
-        return (
-          <ConfirmationItem
-            key={key}
-            label={<FormattedMessage id={program.name.label} defaultMessage={program.name.default_message} />}
-            value={
-              <FormattedMessage
-                id={program.website_description.label}
-                defaultMessage={program.website_description.default_message}
-              />
-            }
+    // updateFormData fans a single saved benefit (e.g. has_section_8) out to
+    // per-white-label keys (section_8, co_section_8, ma_section_8, ...).
+    // Only the active white label's variant is in hasBenefitsPrograms; drop
+    // the rest so the user sees one row per program, not one per WL.
+    const matched = selectedKeys
+      .map((key) => ({ key, program: programsByKey.get(key) }))
+      .filter((entry): entry is { key: string; program: HasBenefitsProgram } => entry.program !== undefined);
+
+    if (matched.length === 0) {
+      return <FormattedMessage id="confirmation.none" defaultMessage="None" />;
+    }
+
+    return matched.map(({ key, program }) => (
+      <ConfirmationItem
+        key={key}
+        label={<FormattedMessage id={program.name.label} defaultMessage={program.name.default_message} />}
+        value={
+          <FormattedMessage
+            id={program.website_description.label}
+            defaultMessage={program.website_description.default_message}
           />
-        );
-      }
-      // Fallback: a benefit was previously selected but is no longer flagged
-      // for this step (e.g. admin toggled show_in_has_benefits_step off).
-      // Render the raw key so the user can still see what was on file.
-      return <ConfirmationItem key={key} value={key} />;
-    });
+        }
+      />
+    ));
   };
 
   const editHasBenefitsAriaLabel = {


### PR DESCRIPTION
## Context & Motivation

The "Current Household Benefits" block on the confirmation step was rendering raw keys (e.g. `section_8`, `co_section_8`, `cesn_section_8`) alongside the active white label's translated program name. Reproduced on `localhost:3000/ma/<screen-uuid>/confirm-information` where a single Section 8 selection rendered as four rows: three raw keys plus one human-readable "Housing Choice Voucher (Section 8)".

Root cause: [updateFormData.tsx](src/Assets/updateFormData.tsx) fans a single saved benefit (`has_section_8`) out to per-white-label entries in `formData.benefits` (`section_8`, `co_section_8`, `ma_section_8`, `cesn_section_8`) to support viewing the same screen across white labels. The active WL's `/has-benefits-programs/` endpoint only returns its own variant, so the sibling-WL keys hit the raw-key fallback at [ConfirmationSteps.tsx:255](src/Components/Confirmation/ConfirmationSteps.tsx#L255). That fallback was written to handle one missing key (admin toggled `show_in_has_benefits_step` off), not three duplicates from sibling white labels.

## Changes Made

- [src/Components/Confirmation/ConfirmationSteps.tsx](src/Components/Confirmation/ConfirmationSteps.tsx): in the `HasBenefits` confirmation block, drop unmatched benefit keys silently instead of rendering them as raw-key fallback rows. Show "None" if no keys match (preserves prior empty-state behavior).
- Import `HasBenefitsProgram` type for the narrowing predicate.

## Testing

- Migrations to run: none
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  - Open an MA screen where Section 8 is the only selected benefit (e.g. `/ma/<screen-uuid>/confirm-information`).
  - Confirm only one row renders under "Current Household Benefits" — the translated "Housing Choice Voucher (Section 8)" — not four.
  - Repeat with a CO screen where SNAP is selected; confirm only the CO SNAP row renders.
  - Edge case: a screen with no selected benefits should still show "None".

## Deployment

- Run script: none
- Update production config: none
- Admin updates needed: none
- Notify team/users of: none

## Notes for Reviewers

- Known limitations: the underlying multi-WL fan-out in `updateFormData.tsx` is unchanged — this PR only fixes the rendering. A more aggressive cleanup would dedupe at the form-data layer, but that touches every WL and is out of scope here.
- Future considerations: when MFB-720 (join-table migration) ships and the lowercase coercion is removed, this filter logic should still hold — it relies on `programsByKey.get(key)` returning the right entry, not on key casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)