### PR TITLE
add washington state to dropdown

### DIFF
--- a/src/Components/Steps/SelectStatePage.tsx
+++ b/src/Components/Steps/SelectStatePage.tsx
@@ -21,6 +21,7 @@ export const STATES: { [key: string]: string } = {
   ma: 'Massachusetts',
   nc: 'North Carolina',
   tx: 'Texas',
+  wa: 'Washington',
 };
 
 const SelectStatePage = () => {


### PR DESCRIPTION
## Summary
Add Washington (wa) as a state option in the benefits calculator state selection dropdown

## Deployment
No manual config needed.

## Test plan
- [ ] Verify Washington appears in the state dropdown on the Select State page
- [ ] Verify selecting Washington navigates to the correct white label route (/wa/...)
- [ ] Verify existing states still work as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Washington as a selectable state option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/benefits-calculator/pull/2108)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->