### PR TITLE
Build HeatPumpJourneyCards component (MFB-978)

### DIFF
--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
@@ -1,0 +1,72 @@
+.heat-pump-journey-cards {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  width: 100%;
+  padding: 1rem 0;
+}
+
+.heat-pump-journey-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background-color: var(--secondary-background-color);
+  border: 1px solid var(--primary-color);
+  border-radius: 0.3rem;
+  padding: 1.25rem;
+}
+
+.heat-pump-journey-card-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background-color: var(--secondary-background-color);
+  border: 1px solid var(--primary-color);
+  color: var(--primary-color);
+  font-family: 'Roboto Slab', serif;
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.heat-pump-journey-card-title {
+  color: var(--primary-color);
+  font-family: 'Roboto Slab', serif;
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.heat-pump-journey-card-description {
+  color: var(--text-color, #000);
+  font-size: 0.95rem;
+  margin: 0;
+  flex-grow: 1;
+}
+
+.heat-pump-journey-card-cta {
+  align-self: flex-start;
+  font-size: 0.85rem;
+  color: white;
+  text-decoration: none;
+  border-radius: 0.75rem;
+  padding: 0.5rem 1rem;
+  background-color: var(--primary-color);
+  font-family: 'Roboto Slab', serif;
+  font-weight: 700;
+  border: 1px solid var(--primary-color);
+  margin-top: auto;
+}
+
+.heat-pump-journey-card-cta:hover,
+.heat-pump-journey-card-cta:focus-visible {
+  background-color: white;
+  color: var(--primary-color);
+}
+
+@media (max-width: 767px) {
+  .heat-pump-journey-cards {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
@@ -12,12 +12,12 @@
 .heat-pump-journey-card {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.7rem;
   background-color: #ffffff;
   border: 1.5px solid var(--icon-color);
   border-radius: 0.3rem;
-  padding: 1rem 0.9rem;
-  aspect-ratio: 9 / 10;
+  padding: 1.25rem 0.7rem;
+  aspect-ratio: 33 / 40;
   overflow: hidden;
 }
 
@@ -25,7 +25,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.6rem;
+  gap: 1rem;
 }
 
 .heat-pump-journey-card-badge {
@@ -60,21 +60,35 @@
   font-size: 0.8rem;
   line-height: 1.35;
   margin: 0;
+  flex-grow: 1;
 }
 
 .heat-pump-journey-card-cta {
-  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: center;
   margin-top: auto;
+  width: 85%;
+  height: 2.25rem;
+  gap: 0.4rem;
   font-size: 0.85rem;
+  line-height: 1;
   color: white;
   text-decoration: none;
   border-radius: 0.75rem;
-  padding: 0.5rem 1rem;
+  padding: 0 1rem;
   background-color: var(--primary-color);
   font-family: 'Roboto Slab', serif;
   font-weight: 700;
   border: 1px solid var(--primary-color);
   white-space: nowrap;
+  box-sizing: border-box;
+}
+
+.heat-pump-journey-card-cta .heat-pump-journey-card-cta-icon {
+  width: 1.1rem !important;
+  height: 1.1rem !important;
 }
 
 .heat-pump-journey-card-cta:hover,

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
@@ -12,12 +12,12 @@
 .heat-pump-journey-card {
   display: flex;
   flex-direction: column;
-  gap: 0.7rem;
+  gap: 0.5rem;
   background-color: #ffffff;
   border: 2px solid var(--icon-color);
   border-radius: 0.3rem;
   padding: 0.8rem;
-  aspect-ratio: 33 / 40;
+  aspect-ratio: 33 / 37.5;
   overflow: hidden;
 }
 
@@ -49,10 +49,9 @@
 .heat-pump-journey-card-title {
   color: var(--primary-color);
   font-family: 'Roboto Slab', serif;
-  font-size: 1.05rem;
+  font-size: 1rem;
   line-height: 1.2;
   margin: 0;
-  white-space: nowrap;
 }
 
 .heat-pump-journey-card-description {

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
@@ -1,7 +1,6 @@
 .energy-calculator-rebate-page-container .heat-pump-journey-cards {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  flex-direction: row;
   gap: 1rem;
   width: 100%;
   padding: 0.25rem 0 1rem;

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
@@ -4,7 +4,7 @@
   flex-direction: row;
   gap: 1rem;
   width: 100%;
-  padding: 1rem 0;
+  padding: 0.25rem 0 1rem;
   box-sizing: border-box;
   align-self: stretch;
 }

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
@@ -14,7 +14,7 @@
   flex-direction: column;
   gap: 0.7rem;
   background-color: #ffffff;
-  border: 1.5px solid var(--icon-color);
+  border: 2px solid var(--icon-color);
   border-radius: 0.3rem;
   padding: 1.25rem 0.7rem;
   aspect-ratio: 33 / 40;

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
@@ -16,7 +16,7 @@
   background-color: #ffffff;
   border: 2px solid var(--icon-color);
   border-radius: 0.3rem;
-  padding: 1.25rem 0.7rem;
+  padding: 0.8rem;
   aspect-ratio: 33 / 40;
   overflow: hidden;
 }

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.css
@@ -1,52 +1,70 @@
-.heat-pump-journey-cards {
+.energy-calculator-rebate-page-container .heat-pump-journey-cards {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
+  flex-direction: row;
   gap: 1rem;
   width: 100%;
   padding: 1rem 0;
+  box-sizing: border-box;
+  align-self: stretch;
 }
 
 .heat-pump-journey-card {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  background-color: var(--secondary-background-color);
-  border: 1px solid var(--primary-color);
+  gap: 0.6rem;
+  background-color: #ffffff;
+  border: 1.5px solid var(--icon-color);
   border-radius: 0.3rem;
-  padding: 1.25rem;
+  padding: 1rem 0.9rem;
+  aspect-ratio: 9 / 10;
+  overflow: hidden;
+}
+
+.heat-pump-journey-card-header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.6rem;
 }
 
 .heat-pump-journey-card-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   width: 1.75rem;
   height: 1.75rem;
   border-radius: 50%;
-  background-color: var(--secondary-background-color);
-  border: 1px solid var(--primary-color);
-  color: var(--primary-color);
+  background-color: #d9d9d9;
+  border: none;
+  color: #000;
   font-family: 'Roboto Slab', serif;
   font-weight: 700;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
+  line-height: 1;
+  text-align: center;
 }
 
 .heat-pump-journey-card-title {
   color: var(--primary-color);
   font-family: 'Roboto Slab', serif;
-  font-size: 1.1rem;
+  font-size: 1.05rem;
+  line-height: 1.2;
   margin: 0;
+  white-space: nowrap;
 }
 
 .heat-pump-journey-card-description {
   color: var(--text-color, #000);
-  font-size: 0.95rem;
+  font-size: 0.8rem;
+  line-height: 1.35;
   margin: 0;
-  flex-grow: 1;
 }
 
 .heat-pump-journey-card-cta {
   align-self: flex-start;
+  margin-top: auto;
   font-size: 0.85rem;
   color: white;
   text-decoration: none;
@@ -56,7 +74,7 @@
   font-family: 'Roboto Slab', serif;
   font-weight: 700;
   border: 1px solid var(--primary-color);
-  margin-top: auto;
+  white-space: nowrap;
 }
 
 .heat-pump-journey-card-cta:hover,
@@ -66,7 +84,12 @@
 }
 
 @media (max-width: 767px) {
-  .heat-pump-journey-cards {
+  .energy-calculator-rebate-page-container .heat-pump-journey-cards {
     grid-template-columns: 1fr;
+    padding: 0;
+  }
+
+  .heat-pump-journey-card {
+    aspect-ratio: auto;
   }
 }

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.test.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.test.tsx
@@ -2,18 +2,12 @@ import { render, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { MemoryRouter } from 'react-router-dom';
 import HeatPumpJourneyCards from './HeatPumpJourneyCards';
-import { useFeatureFlag } from '../../../Config/configHook';
 import { useResultsLink } from '../../../Results/Results';
-
-jest.mock('../../../Config/configHook', () => ({
-  useFeatureFlag: jest.fn(),
-}));
 
 jest.mock('../../../Results/Results', () => ({
   useResultsLink: jest.fn(),
 }));
 
-const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<typeof useFeatureFlag>;
 const mockUseResultsLink = useResultsLink as jest.MockedFunction<typeof useResultsLink>;
 
 const renderCards = () =>
@@ -31,27 +25,7 @@ describe('HeatPumpJourneyCards', () => {
     mockUseResultsLink.mockImplementation((link: string) => `/co/test-uuid/${link}`);
   });
 
-  it('renders nothing when the cesn_heat_pump_journey feature flag is disabled', () => {
-    mockUseFeatureFlag.mockReturnValue(false);
-
-    const { container } = renderCards();
-
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it('checks the cesn_heat_pump_journey feature flag', () => {
-    mockUseFeatureFlag.mockReturnValue(false);
-
-    renderCards();
-
-    expect(mockUseFeatureFlag).toHaveBeenCalledWith('cesn_heat_pump_journey');
-  });
-
-  describe('when the feature flag is enabled', () => {
-    beforeEach(() => {
-      mockUseFeatureFlag.mockReturnValue(true);
-    });
-
+  describe('rendering', () => {
     it('renders all three cards with titles', () => {
       renderCards();
 

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.test.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.test.tsx
@@ -1,14 +1,21 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { MemoryRouter } from 'react-router-dom';
 import HeatPumpJourneyCards from './HeatPumpJourneyCards';
 import { useResultsLink } from '../../../Results/Results';
+import dataLayerPush from '../../../../Assets/analytics';
 
 jest.mock('../../../Results/Results', () => ({
   useResultsLink: jest.fn(),
 }));
 
+jest.mock('../../../../Assets/analytics', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
 const mockUseResultsLink = useResultsLink as jest.MockedFunction<typeof useResultsLink>;
+const mockDataLayerPush = dataLayerPush as jest.MockedFunction<typeof dataLayerPush>;
 
 const renderCards = () =>
   render(
@@ -58,6 +65,28 @@ describe('HeatPumpJourneyCards', () => {
 
       const connectNow = screen.getByRole('link', { name: /connect now/i });
       expect(connectNow).toHaveAttribute('href', '/co/test-uuid/results/heat-pump-contractors');
+    });
+
+    it('exposes the section with an accessible label', () => {
+      renderCards();
+
+      expect(screen.getByRole('region', { name: /heat pump journey/i })).toBeInTheDocument();
+    });
+
+    it('fires the heat_pump_journey_learn_more_click analytics event when Learn more is clicked', () => {
+      renderCards();
+
+      fireEvent.click(screen.getByRole('link', { name: /learn more/i }));
+
+      expect(mockDataLayerPush).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'outbound_click',
+          action: 'heat_pump_journey_learn_more_click',
+          category: 'heat_pump_journey',
+          label: 'Power Ahead Colorado - Why Heat Pumps',
+          url: 'https://poweraheadcolorado.org/why-heat-pumps?utm_source=cesn',
+        }),
+      );
     });
   });
 });

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.test.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { MemoryRouter } from 'react-router-dom';
+import HeatPumpJourneyCards from './HeatPumpJourneyCards';
+import { useFeatureFlag } from '../../../Config/configHook';
+import { useResultsLink } from '../../../Results/Results';
+
+jest.mock('../../../Config/configHook', () => ({
+  useFeatureFlag: jest.fn(),
+}));
+
+jest.mock('../../../Results/Results', () => ({
+  useResultsLink: jest.fn(),
+}));
+
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<typeof useFeatureFlag>;
+const mockUseResultsLink = useResultsLink as jest.MockedFunction<typeof useResultsLink>;
+
+const renderCards = () =>
+  render(
+    <IntlProvider locale="en" defaultLocale="en">
+      <MemoryRouter>
+        <HeatPumpJourneyCards />
+      </MemoryRouter>
+    </IntlProvider>,
+  );
+
+describe('HeatPumpJourneyCards', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseResultsLink.mockImplementation((link: string) => `/co/test-uuid/${link}`);
+  });
+
+  it('renders nothing when the cesn_heat_pump_journey feature flag is disabled', () => {
+    mockUseFeatureFlag.mockReturnValue(false);
+
+    const { container } = renderCards();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('checks the cesn_heat_pump_journey feature flag', () => {
+    mockUseFeatureFlag.mockReturnValue(false);
+
+    renderCards();
+
+    expect(mockUseFeatureFlag).toHaveBeenCalledWith('cesn_heat_pump_journey');
+  });
+
+  describe('when the feature flag is enabled', () => {
+    beforeEach(() => {
+      mockUseFeatureFlag.mockReturnValue(true);
+    });
+
+    it('renders all three cards with titles', () => {
+      renderCards();
+
+      expect(screen.getByRole('heading', { name: /why get a heat pump\?/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /will it impact my bills\?/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /whom should i hire\?/i })).toBeInTheDocument();
+    });
+
+    it('renders the Learn more CTA pointing to Power Ahead Colorado in a new tab with utm_source', () => {
+      renderCards();
+
+      const learnMore = screen.getByRole('link', { name: /learn more/i });
+      expect(learnMore).toHaveAttribute(
+        'href',
+        'https://poweraheadcolorado.org/why-heat-pumps?utm_source=cesn',
+      );
+      expect(learnMore).toHaveAttribute('target', '_blank');
+      expect(learnMore).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('routes the Calculate impact CTA to the internal bills-impact path', () => {
+      renderCards();
+
+      const calculateImpact = screen.getByRole('link', { name: /calculate impact/i });
+      expect(calculateImpact).toHaveAttribute('href', '/co/test-uuid/results/heat-pump-bills-impact');
+    });
+
+    it('routes the Connect now CTA to the internal contractors path', () => {
+      renderCards();
+
+      const connectNow = screen.getByRole('link', { name: /connect now/i });
+      expect(connectNow).toHaveAttribute('href', '/co/test-uuid/results/heat-pump-contractors');
+    });
+  });
+});

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.tsx
@@ -19,15 +19,17 @@ export default function HeatPumpJourneyCards() {
   return (
     <section className="heat-pump-journey-cards" aria-label="Heat pump journey">
       <article className="heat-pump-journey-card">
-        <span className="heat-pump-journey-card-badge" aria-hidden="true">
-          1
-        </span>
-        <h3 className="heat-pump-journey-card-title">
-          <FormattedMessage
-            id="energyCalculator.heatPumpJourney.card1.title"
-            defaultMessage="Why get a heat pump?"
-          />
-        </h3>
+        <div className="heat-pump-journey-card-header">
+          <span className="heat-pump-journey-card-badge" aria-hidden="true">
+            1
+          </span>
+          <h3 className="heat-pump-journey-card-title">
+            <FormattedMessage
+              id="energyCalculator.heatPumpJourney.card1.title"
+              defaultMessage="Why get a heat pump?"
+            />
+          </h3>
+        </div>
         <p className="heat-pump-journey-card-description">
           <FormattedMessage
             id="energyCalculator.heatPumpJourney.card1.description"
@@ -46,15 +48,17 @@ export default function HeatPumpJourneyCards() {
       </article>
 
       <article className="heat-pump-journey-card">
-        <span className="heat-pump-journey-card-badge" aria-hidden="true">
-          2
-        </span>
-        <h3 className="heat-pump-journey-card-title">
-          <FormattedMessage
-            id="energyCalculator.heatPumpJourney.card2.title"
-            defaultMessage="Will it impact my bills?"
-          />
-        </h3>
+        <div className="heat-pump-journey-card-header">
+          <span className="heat-pump-journey-card-badge" aria-hidden="true">
+            2
+          </span>
+          <h3 className="heat-pump-journey-card-title">
+            <FormattedMessage
+              id="energyCalculator.heatPumpJourney.card2.title"
+              defaultMessage="Will it impact my bills?"
+            />
+          </h3>
+        </div>
         <p className="heat-pump-journey-card-description">
           <FormattedMessage
             id="energyCalculator.heatPumpJourney.card2.description"
@@ -67,15 +71,17 @@ export default function HeatPumpJourneyCards() {
       </article>
 
       <article className="heat-pump-journey-card">
-        <span className="heat-pump-journey-card-badge" aria-hidden="true">
-          3
-        </span>
-        <h3 className="heat-pump-journey-card-title">
-          <FormattedMessage
-            id="energyCalculator.heatPumpJourney.card3.title"
-            defaultMessage="Whom should I hire?"
-          />
-        </h3>
+        <div className="heat-pump-journey-card-header">
+          <span className="heat-pump-journey-card-badge" aria-hidden="true">
+            3
+          </span>
+          <h3 className="heat-pump-journey-card-title">
+            <FormattedMessage
+              id="energyCalculator.heatPumpJourney.card3.title"
+              defaultMessage="Whom should I hire?"
+            />
+          </h3>
+        </div>
         <p className="heat-pump-journey-card-description">
           <FormattedMessage
             id="energyCalculator.heatPumpJourney.card3.description"

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.tsx
@@ -1,0 +1,91 @@
+import { FormattedMessage } from 'react-intl';
+import { Link } from 'react-router-dom';
+import { TrackedOutboundLink } from '../../../Common/TrackedOutboundLink';
+import { useFeatureFlag } from '../../../Config/configHook';
+import { useResultsLink } from '../../../Results/Results';
+import './HeatPumpJourneyCards.css';
+
+const POWER_AHEAD_LEARN_MORE_URL = 'https://poweraheadcolorado.org/why-heat-pumps?utm_source=cesn';
+
+export default function HeatPumpJourneyCards() {
+  const isEnabled = useFeatureFlag('cesn_heat_pump_journey');
+  const billsImpactLink = useResultsLink('results/heat-pump-bills-impact');
+  const contractorsLink = useResultsLink('results/heat-pump-contractors');
+
+  if (!isEnabled) {
+    return null;
+  }
+
+  return (
+    <section className="heat-pump-journey-cards" aria-label="Heat pump journey">
+      <article className="heat-pump-journey-card">
+        <span className="heat-pump-journey-card-badge" aria-hidden="true">
+          1
+        </span>
+        <h3 className="heat-pump-journey-card-title">
+          <FormattedMessage
+            id="energyCalculator.heatPumpJourney.card1.title"
+            defaultMessage="Why get a heat pump?"
+          />
+        </h3>
+        <p className="heat-pump-journey-card-description">
+          <FormattedMessage
+            id="energyCalculator.heatPumpJourney.card1.description"
+            defaultMessage="Many customers see cost savings from switching to a heat pump. They reduce your carbon footprint and can improve air quality."
+          />
+        </p>
+        <TrackedOutboundLink
+          href={POWER_AHEAD_LEARN_MORE_URL}
+          action="heat_pump_journey_learn_more_click"
+          label="Power Ahead Colorado - Why Heat Pumps"
+          category="heat_pump_journey"
+          className="heat-pump-journey-card-cta"
+        >
+          <FormattedMessage id="energyCalculator.heatPumpJourney.card1.cta" defaultMessage="Learn more" />
+        </TrackedOutboundLink>
+      </article>
+
+      <article className="heat-pump-journey-card">
+        <span className="heat-pump-journey-card-badge" aria-hidden="true">
+          2
+        </span>
+        <h3 className="heat-pump-journey-card-title">
+          <FormattedMessage
+            id="energyCalculator.heatPumpJourney.card2.title"
+            defaultMessage="Will it impact my bills?"
+          />
+        </h3>
+        <p className="heat-pump-journey-card-description">
+          <FormattedMessage
+            id="energyCalculator.heatPumpJourney.card2.description"
+            defaultMessage="Learn how your household may see potential energy bill changes and emissions reductions."
+          />
+        </p>
+        <Link to={billsImpactLink} className="heat-pump-journey-card-cta">
+          <FormattedMessage id="energyCalculator.heatPumpJourney.card2.cta" defaultMessage="Calculate impact" />
+        </Link>
+      </article>
+
+      <article className="heat-pump-journey-card">
+        <span className="heat-pump-journey-card-badge" aria-hidden="true">
+          3
+        </span>
+        <h3 className="heat-pump-journey-card-title">
+          <FormattedMessage
+            id="energyCalculator.heatPumpJourney.card3.title"
+            defaultMessage="Whom should I hire?"
+          />
+        </h3>
+        <p className="heat-pump-journey-card-description">
+          <FormattedMessage
+            id="energyCalculator.heatPumpJourney.card3.description"
+            defaultMessage="Heat pumps are an upgrade to your HVAC system. Consult with a registered contractor to help you plan your heat pump installation."
+          />
+        </p>
+        <Link to={contractorsLink} className="heat-pump-journey-card-cta">
+          <FormattedMessage id="energyCalculator.heatPumpJourney.card3.cta" defaultMessage="Connect now" />
+        </Link>
+      </article>
+    </section>
+  );
+}

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.tsx
@@ -1,5 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { TrackedOutboundLink } from '../../../Common/TrackedOutboundLink';
 import { useFeatureFlag } from '../../../Config/configHook';
 import { useResultsLink } from '../../../Results/Results';
@@ -44,6 +45,7 @@ export default function HeatPumpJourneyCards() {
           className="heat-pump-journey-card-cta"
         >
           <FormattedMessage id="energyCalculator.heatPumpJourney.card1.cta" defaultMessage="Learn more" />
+          <OpenInNewIcon className="heat-pump-journey-card-cta-icon" aria-hidden="true" />
         </TrackedOutboundLink>
       </article>
 

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.tsx
@@ -2,21 +2,16 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { TrackedOutboundLink } from '../../../Common/TrackedOutboundLink';
-import { useFeatureFlag } from '../../../Config/configHook';
 import { useResultsLink } from '../../../Results/Results';
 import './HeatPumpJourneyCards.css';
 
+// Caller is responsible for gating render on the `cesn_heat_pump_journey` flag.
 const POWER_AHEAD_LEARN_MORE_URL = 'https://poweraheadcolorado.org/why-heat-pumps?utm_source=cesn';
 
 export default function HeatPumpJourneyCards() {
   const intl = useIntl();
-  const isEnabled = useFeatureFlag('cesn_heat_pump_journey');
   const billsImpactLink = useResultsLink('results/heat-pump-bills-impact');
   const contractorsLink = useResultsLink('results/heat-pump-contractors');
-
-  if (!isEnabled) {
-    return null;
-  }
 
   const sectionAriaLabel = intl.formatMessage({
     id: 'energyCalculator.heatPumpJourney.sectionAriaLabel',

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.tsx
@@ -1,4 +1,4 @@
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { TrackedOutboundLink } from '../../../Common/TrackedOutboundLink';
@@ -9,6 +9,7 @@ import './HeatPumpJourneyCards.css';
 const POWER_AHEAD_LEARN_MORE_URL = 'https://poweraheadcolorado.org/why-heat-pumps?utm_source=cesn';
 
 export default function HeatPumpJourneyCards() {
+  const intl = useIntl();
   const isEnabled = useFeatureFlag('cesn_heat_pump_journey');
   const billsImpactLink = useResultsLink('results/heat-pump-bills-impact');
   const contractorsLink = useResultsLink('results/heat-pump-contractors');
@@ -17,8 +18,13 @@ export default function HeatPumpJourneyCards() {
     return null;
   }
 
+  const sectionAriaLabel = intl.formatMessage({
+    id: 'energyCalculator.heatPumpJourney.sectionAriaLabel',
+    defaultMessage: 'Heat pump journey',
+  });
+
   return (
-    <section className="heat-pump-journey-cards" aria-label="Heat pump journey">
+    <section className="heat-pump-journey-cards" aria-label={sectionAriaLabel}>
       <article className="heat-pump-journey-card">
         <div className="heat-pump-journey-card-header">
           <span className="heat-pump-journey-card-badge" aria-hidden="true">

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/HeatPumpJourneyCards.tsx
@@ -5,7 +5,9 @@ import { TrackedOutboundLink } from '../../../Common/TrackedOutboundLink';
 import { useResultsLink } from '../../../Results/Results';
 import './HeatPumpJourneyCards.css';
 
-// Caller is responsible for gating render on the `cesn_heat_pump_journey` flag.
+// CESN-specific feature (Colorado Energy Savings Network). Caller is responsible
+// for gating render on the `cesn_heat_pump_journey` flag. The hardcoded utm_source
+// below is intentional — this component is not expected to render for other white labels.
 const POWER_AHEAD_LEARN_MORE_URL = 'https://poweraheadcolorado.org/why-heat-pumps?utm_source=cesn';
 
 export default function HeatPumpJourneyCards() {

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/index.ts
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/index.ts
@@ -1,0 +1,1 @@
+export { default as HeatPumpJourneyCards } from './HeatPumpJourneyCards';

--- a/src/Components/EnergyCalculator/Results/RebatePage.css
+++ b/src/Components/EnergyCalculator/Results/RebatePage.css
@@ -33,6 +33,33 @@
   padding: 1rem;
 }
 
+.energy-calculator-rebate-page-container section.energy-calculator-rebate-page-rebates-list-full-width {
+  width: 100%;
+  padding: 0;
+}
+
+.energy-calculator-rebate-page-container .energy-calculator-rebate-page-rebates-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  align-self: flex-start;
+  color: var(--secondary-color);
+  margin: 0.5rem 0 .5rem;
+}
+
+.energy-calculator-rebate-page-container .energy-calculator-rebate-page-rebates-heading svg {
+  display: inline-flex;
+  width: 2rem;
+  height: 1.6rem;
+  color: var(--icon-color) !important;
+}
+
+.energy-calculator-rebate-page-container .energy-calculator-rebate-page-rebates-heading svg,
+.energy-calculator-rebate-page-container .energy-calculator-rebate-page-rebates-heading svg * {
+  fill: none !important;
+  stroke: currentColor !important;
+}
+
 .energy-calculator-rebate-page-rebate-card {
   display: flex;
   flex-direction: column;

--- a/src/Components/EnergyCalculator/Results/RebatePage.css
+++ b/src/Components/EnergyCalculator/Results/RebatePage.css
@@ -33,7 +33,8 @@
   padding: 1rem;
 }
 
-.energy-calculator-rebate-page-container .energy-calculator-rebate-page-rebates-list-full-width {
+.energy-calculator-rebate-page-container
+  .energy-calculator-rebate-page-rebates-list.energy-calculator-rebate-page-rebates-list-full-width {
   width: 100%;
   padding: 0;
 }

--- a/src/Components/EnergyCalculator/Results/RebatePage.css
+++ b/src/Components/EnergyCalculator/Results/RebatePage.css
@@ -25,7 +25,7 @@
   stroke: currentColor !important;
 }
 
-.energy-calculator-rebate-page-container section {
+.energy-calculator-rebate-page-container .energy-calculator-rebate-page-rebates-list {
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -33,7 +33,7 @@
   padding: 1rem;
 }
 
-.energy-calculator-rebate-page-container section.energy-calculator-rebate-page-rebates-list-full-width {
+.energy-calculator-rebate-page-container .energy-calculator-rebate-page-rebates-list-full-width {
   width: 100%;
   padding: 0;
 }
@@ -173,7 +173,7 @@
     align-self: flex-start;
   }
 
-  .energy-calculator-rebate-page-container section {
+  .energy-calculator-rebate-page-container .energy-calculator-rebate-page-rebates-list {
     align-self: center;
     width: 100%;
     padding: 0;
@@ -181,5 +181,9 @@
 
   .energy-calculator-rebate-page-rebate-card {
     padding: 1.25rem;
+  }
+
+  .energy-calculator-rebate-page-container .energy-calculator-rebate-page-rebates-heading {
+    margin-top: 1.5rem;
   }
 }

--- a/src/Components/EnergyCalculator/Results/RebatePage.test.tsx
+++ b/src/Components/EnergyCalculator/Results/RebatePage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { IntlProvider } from 'react-intl';
+import { FormattedMessage, IntlProvider } from 'react-intl';
 import { MemoryRouter } from 'react-router-dom';
 import EnergyCalculatorRebatePage from './RebatePage';
 import { Context } from '../../Wrapper/Wrapper';
@@ -35,7 +35,7 @@ const mockUseResultsLink = useResultsLink as jest.MockedFunction<typeof useResul
 
 const buildCategory = (type: EnergyCalculatorRebateCategoryType): EnergyCalculatorRebateCategory => ({
   type,
-  name: 'Category Name' as unknown as EnergyCalculatorRebateCategory['name'],
+  name: <FormattedMessage id="test.category.name" defaultMessage="Category Name" />,
   rebates: [],
 });
 

--- a/src/Components/EnergyCalculator/Results/RebatePage.test.tsx
+++ b/src/Components/EnergyCalculator/Results/RebatePage.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { MemoryRouter } from 'react-router-dom';
+import EnergyCalculatorRebatePage from './RebatePage';
+import { Context } from '../../Wrapper/Wrapper';
+import { useFeatureFlag } from '../../Config/configHook';
+import { useResultsLink } from '../../Results/Results';
+import type { EnergyCalculatorRebateCategory, EnergyCalculatorRebateCategoryType } from './rebateTypes';
+
+jest.mock('../../Config/configHook', () => ({
+  useFeatureFlag: jest.fn(),
+}));
+
+jest.mock('../../Results/Results', () => ({
+  useResultsLink: jest.fn(),
+}));
+
+// HeatPumpJourneyCards is exercised in its own test file; stub here to keep this
+// test focused on RebatePage's conditional layout logic.
+jest.mock('./HeatPumpJourney', () => ({
+  HeatPumpJourneyCards: () => <div data-testid="heat-pump-journey-cards" />,
+}));
+
+// renderCategoryDescription pulls in formData; stub to a no-op for these tests.
+jest.mock('./rebateTypes', () => {
+  const actual = jest.requireActual('./rebateTypes');
+  return {
+    ...actual,
+    renderCategoryDescription: () => null,
+  };
+});
+
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<typeof useFeatureFlag>;
+const mockUseResultsLink = useResultsLink as jest.MockedFunction<typeof useResultsLink>;
+
+const buildCategory = (type: EnergyCalculatorRebateCategoryType): EnergyCalculatorRebateCategory => ({
+  type,
+  name: 'Category Name' as unknown as EnergyCalculatorRebateCategory['name'],
+  rebates: [],
+});
+
+const renderPage = (type: EnergyCalculatorRebateCategoryType) =>
+  render(
+    <IntlProvider locale="en" defaultLocale="en">
+      <MemoryRouter>
+        <Context.Provider value={{ formData: {} } as any}>
+          <EnergyCalculatorRebatePage rebateCategory={buildCategory(type)} />
+        </Context.Provider>
+      </MemoryRouter>
+    </IntlProvider>,
+  );
+
+describe('EnergyCalculatorRebatePage heat pump journey gating', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseResultsLink.mockImplementation((link: string) => `/co/test-uuid/${link}`);
+  });
+
+  it('does not render the heat pump journey when the feature flag is off (hvac category)', () => {
+    mockUseFeatureFlag.mockReturnValue(false);
+
+    renderPage('hvac');
+
+    expect(screen.queryByTestId('heat-pump-journey-cards')).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /rebates/i, level: 2 })).not.toBeInTheDocument();
+  });
+
+  it('does not render the heat pump journey for non-hvac categories even when the flag is on', () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+
+    renderPage('waterHeater');
+
+    expect(screen.queryByTestId('heat-pump-journey-cards')).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /rebates/i, level: 2 })).not.toBeInTheDocument();
+  });
+
+  it('renders the heat pump journey and Rebates heading for the hvac category when the flag is on', () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+
+    renderPage('hvac');
+
+    expect(screen.getByTestId('heat-pump-journey-cards')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /rebates/i, level: 2 })).toBeInTheDocument();
+  });
+});

--- a/src/Components/EnergyCalculator/Results/RebatePage.tsx
+++ b/src/Components/EnergyCalculator/Results/RebatePage.tsx
@@ -11,6 +11,7 @@ import { useMemo, useContext } from 'react';
 import { TrackedOutboundLink } from '../../Common/TrackedOutboundLink';
 import { Context } from '../../Wrapper/Wrapper';
 import { HeatPumpJourneyCards } from './HeatPumpJourney';
+import { useFeatureFlag } from '../../Config/configHook';
 
 // Format expiration date from ISO string to readable format
 const formatExpirationDate = (dateString: string): string => {
@@ -41,6 +42,7 @@ type RebatePageProps = {
 export default function EnergyCalculatorRebatePage({ rebateCategory }: RebatePageProps) {
   const backLink = useResultsLink(`results/benefits`);
   const { formData } = useContext(Context);
+  const showHeatPumpJourney = useFeatureFlag('cesn_heat_pump_journey') && rebateCategory.type === 'hvac';
 
   return (
     <main className="benefits-form">
@@ -56,8 +58,16 @@ export default function EnergyCalculatorRebatePage({ rebateCategory }: RebatePag
           <span>{rebateCategory.name}</span>
         </h1>
         {renderCategoryDescription(rebateCategory.type, formData)}
-        {rebateCategory.type === 'hvac' && <HeatPumpJourneyCards />}
-        <section>
+        {showHeatPumpJourney && <HeatPumpJourneyCards />}
+        {showHeatPumpJourney && (
+          <h2 className="energy-calculator-rebate-page-rebates-heading">
+            <Coin />
+            <span>
+              <FormattedMessage id="energyCalculator.rebatePage.rebatesHeading" defaultMessage="Rebates" />
+            </span>
+          </h2>
+        )}
+        <section className={showHeatPumpJourney ? 'energy-calculator-rebate-page-rebates-list-full-width' : undefined}>
           {rebateCategory.rebates.map((rebate, i) => {
             return <RebateCard rebate={rebate} rebateCategory={rebateCategory} key={i} />;
           })}

--- a/src/Components/EnergyCalculator/Results/RebatePage.tsx
+++ b/src/Components/EnergyCalculator/Results/RebatePage.tsx
@@ -10,6 +10,7 @@ import './RebatePage.css';
 import { useMemo, useContext } from 'react';
 import { TrackedOutboundLink } from '../../Common/TrackedOutboundLink';
 import { Context } from '../../Wrapper/Wrapper';
+import { HeatPumpJourneyCards } from './HeatPumpJourney';
 
 // Format expiration date from ISO string to readable format
 const formatExpirationDate = (dateString: string): string => {
@@ -55,6 +56,7 @@ export default function EnergyCalculatorRebatePage({ rebateCategory }: RebatePag
           <span>{rebateCategory.name}</span>
         </h1>
         {renderCategoryDescription(rebateCategory.type, formData)}
+        {rebateCategory.type === 'hvac' && <HeatPumpJourneyCards />}
         <section>
           {rebateCategory.rebates.map((rebate, i) => {
             return <RebateCard rebate={rebate} rebateCategory={rebateCategory} key={i} />;

--- a/src/Components/EnergyCalculator/Results/RebatePage.tsx
+++ b/src/Components/EnergyCalculator/Results/RebatePage.tsx
@@ -58,21 +58,21 @@ export default function EnergyCalculatorRebatePage({ rebateCategory }: RebatePag
           <span>{rebateCategory.name}</span>
         </h1>
         {renderCategoryDescription(rebateCategory.type, formData)}
-        {showHeatPumpJourney && <HeatPumpJourneyCards />}
         {showHeatPumpJourney && (
-          <h2 className="energy-calculator-rebate-page-rebates-heading">
-            <Coin />
-            <span>
-              <FormattedMessage id="energyCalculator.rebatePage.rebatesHeading" defaultMessage="Rebates" />
-            </span>
-          </h2>
+          <>
+            <HeatPumpJourneyCards />
+            <h2 className="energy-calculator-rebate-page-rebates-heading">
+              <Coin />
+              <span>
+                <FormattedMessage id="energyCalculator.rebatePage.rebatesHeading" defaultMessage="Rebates" />
+              </span>
+            </h2>
+          </>
         )}
         <section
-          className={
-            showHeatPumpJourney
-              ? 'energy-calculator-rebate-page-rebates-list energy-calculator-rebate-page-rebates-list-full-width'
-              : 'energy-calculator-rebate-page-rebates-list'
-          }
+          className={`energy-calculator-rebate-page-rebates-list${
+            showHeatPumpJourney ? ' energy-calculator-rebate-page-rebates-list-full-width' : ''
+          }`}
         >
           {rebateCategory.rebates.map((rebate, i) => {
             return <RebateCard rebate={rebate} rebateCategory={rebateCategory} key={i} />;

--- a/src/Components/EnergyCalculator/Results/RebatePage.tsx
+++ b/src/Components/EnergyCalculator/Results/RebatePage.tsx
@@ -67,7 +67,13 @@ export default function EnergyCalculatorRebatePage({ rebateCategory }: RebatePag
             </span>
           </h2>
         )}
-        <section className={showHeatPumpJourney ? 'energy-calculator-rebate-page-rebates-list-full-width' : undefined}>
+        <section
+          className={
+            showHeatPumpJourney
+              ? 'energy-calculator-rebate-page-rebates-list energy-calculator-rebate-page-rebates-list-full-width'
+              : 'energy-calculator-rebate-page-rebates-list'
+          }
+        >
           {rebateCategory.rebates.map((rebate, i) => {
             return <RebateCard rebate={rebate} rebateCategory={rebateCategory} key={i} />;
           })}


### PR DESCRIPTION
## Context & Motivation

Implements [MFB-978](https://linear.app/myfriendben/issue/MFB-978/step-2a-build-why-get-a-heat-pump-3-card-section-component): Step 2a of the CESN heat pump UX journey on the HVAC rebate results page. Builds the "Why get a heat pump?" 3-card section, wires it into the HVAC rebate page along with a new "Rebates" section heading, and gates the entire treatment behind the `cesn_heat_pump_journey` feature flag so it stays dormant in prod until the flag is flipped (and until Steps 2b/2c land the destination routes for cards 2 and 3).

- Fixes MFB-978
- Related: Step 2b creates the `Calculate impact` destination, Step 2c creates the `Connect now` destination, Step 5 is the broader page wiring/layout work

## Changes Made

- New `HeatPumpJourneyCards` component (with CSS, tests, index) renders three feature-flagged cards above the HVAC rebate list. Card 1 opens Power Ahead Colorado in a new tab via `TrackedOutboundLink` (action `heat_pump_journey_learn_more_click`, `utm_source=cesn`); Cards 2 and 3 link to internal routes via `useResultsLink` (paths land in Steps 2b/2c — 404 until then, safe because of the flag)
- `RebatePage.tsx` gates the cards, the new "Rebates" `<h2>`, and the full-width rebate-list modifier on a single `showHeatPumpJourney = useFeatureFlag('cesn_heat_pump_journey') && rebateCategory.type === 'hvac'` value
- `RebatePage.css` swaps the broad `.container section` rule for an explicit `.energy-calculator-rebate-page-rebates-list` class, and uses a compound selector for the full-width modifier so specificity is order-independent
- New `RebatePage.test.tsx` covers the flag/category gating (flag off → hidden; non-HVAC + flag on → hidden; HVAC + flag on → shown)
- Card layout: 3-column grid, `aspect-ratio: 33 / 37.5` for equal heights, CTAs aligned via `margin-top: auto`; single-column with relaxed aspect ratio under 768px

<img width="970" height="1127" alt="image" src="https://github.com/user-attachments/assets/3a635322-37f5-44d2-a8f1-6bff38d0f3ad" />

## Testing

- Migrations to run: none
- Configuration updates needed: the `cesn_heat_pump_journey` flag already exists in config; flip to `true` when ready to expose the section in a given environment
- Environment variables/settings to add: none
- Manual testing steps:
  - With `cesn_heat_pump_journey: false` (default), navigate to any HVAC rebate page (e.g. `/cesn/<uuid>/results/energy-rebates/hvac`) and confirm the 3-card section and new "Rebates" heading do **not** render and the rebate list stays at its original 80% width
  - With the flag flipped on, the heat pump cards section, the "Rebates" heading, and a full-width rebate list all appear together
  - Card 1 "Learn more" opens Power Ahead Colorado in a new tab with `utm_source=cesn`
  - Cards 2 and 3 navigate to the (currently 404'ing) internal paths — expected until Steps 2b/2c land
  - Confirm the treatment does **not** render on non-HVAC rebate category pages (waterHeater, stove, efficiencyWeatherization, electricVehiclesAndBikes)
- Unit tests: `npm test -- --watchAll=false --testPathPattern="EnergyCalculator/Results/(HeatPumpJourney|RebatePage)"` — all 9 pass (6 component tests + 3 page-gating tests)

## Deployment

- Run script: none
- Update production config: none in this PR. The `cesn_heat_pump_journey` flag exists already and stays `false` until Steps 2b/2c land and the design is QA'd in staging
- Admin updates needed: **add the following translation IDs in the admin portal** before flipping the flag on in any environment. All 11 are new IDs introduced by this PR (English defaults shown — translate per locale as needed):

  | ID | English text |
  |---|---|
  | `energyCalculator.rebatePage.rebatesHeading` | Rebates |
  | `energyCalculator.heatPumpJourney.sectionAriaLabel` | Heat pump journey |
  | `energyCalculator.heatPumpJourney.card1.title` | Why get a heat pump? |
  | `energyCalculator.heatPumpJourney.card1.description` | Many customers see cost savings from switching to a heat pump. They reduce your carbon footprint and can improve air quality. |
  | `energyCalculator.heatPumpJourney.card1.cta` | Learn more |
  | `energyCalculator.heatPumpJourney.card2.title` | Will it impact my bills? |
  | `energyCalculator.heatPumpJourney.card2.description` | Learn how your household may see potential energy bill changes and emissions reductions. |
  | `energyCalculator.heatPumpJourney.card2.cta` | Calculate impact |
  | `energyCalculator.heatPumpJourney.card3.title` | Whom should I hire? |
  | `energyCalculator.heatPumpJourney.card3.description` | Heat pumps are an upgrade to your HVAC system. Consult with a registered contractor to help you plan your heat pump installation. |
  | `energyCalculator.heatPumpJourney.card3.cta` | Connect now |

- Notify team/users of: nothing yet — treatment is dormant in prod. Note for QA: flipping the flag on staging **before** Steps 2b/2c land will expose 404s on Cards 2 and 3's CTAs; coordinate flag-flip timing with those merges

## Notes for Reviewers

- Known limitations:
  - Cards 2/3 CTA paths intentionally point to routes that don't exist yet. They are wired now so Steps 2b/2c only need to land the destinations without touching this component. The feature flag keeps the whole treatment hidden in the meantime
  - HVAC-only restriction and full-width override both live at the `RebatePage` call site rather than inside the component. If we ever want the treatment on additional categories, that lives where it's wired
  - The `utm_source=cesn` on the Power Ahead Colorado link is hardcoded (the rebate-card outbound links build the full UTM quadruple at runtime). Acceptable because this section is flag-gated to CESN only, but worth aligning if marketing later wants the same attribution shape across all CESN outbounds
- Future considerations:
  - Once Steps 2b/2c land, the internal CTA paths here should stay in sync with the actual route definitions added in `src/routes/results.tsx`
  - The external-link icon is MUI `OpenInNewIcon`; if the design system later standardizes on a different external-link affordance, swap there

🤖 Generated with [Claude Code](https://claude.com/claude-code)