### PR TITLE
MFB-1012: FE - Map needs_disability_resources for MA Disability Resources tile

### DIFF
--- a/src/Assets/updateFormData.tsx
+++ b/src/Assets/updateFormData.tsx
@@ -143,6 +143,7 @@ export function useUpdateFormData() {
         legalServices: response.needs_legal_services ?? false,
         savings: response.needs_college_savings ?? false,
         veteranServices: response.needs_veteran_services ?? false,
+        disabilityResources: response.needs_disability_resources ?? false,
       },
       signUpInfo: {
         email: '',

--- a/src/Assets/updateScreen.ts
+++ b/src/Assets/updateScreen.ts
@@ -121,6 +121,7 @@ const getScreensBody = (formData: FormData, languageCode: Language, whiteLabel: 
     needs_legal_services: formData.acuteHHConditions.legalServices ?? null,
     needs_college_savings: formData.acuteHHConditions.savings ?? null,
     needs_veteran_services: formData.acuteHHConditions.veteranServices ?? null,
+    needs_disability_resources: formData.acuteHHConditions.disabilityResources ?? null,
     utm_id: formData.utm?.id ?? null,
     utm_source: formData.utm?.source ?? null,
     utm_medium: formData.utm?.medium ?? null,

--- a/src/Types/ApiFormData.ts
+++ b/src/Types/ApiFormData.ts
@@ -245,6 +245,7 @@ export type ApiFormData = {
   needs_legal_services: boolean | null;
   needs_college_savings: boolean | null;
   needs_veteran_services: boolean | null;
+  needs_disability_resources: boolean | null;
   utm_id: string | null;
   utm_source: string | null;
   utm_medium: string | null;


### PR DESCRIPTION
## Context & Motivation

Backend companion: [MyFriendBen/benefits-api#1542](https://github.com/MyFriendBen/benefits-api/pull/1542)
Linear: [MFB-1012](https://linear.app/myfriendben/issue/MFB-1012/ma-add-able-accounts-under-new-disability-additional-resource-tile)

The backend introduces a new \`needs_disability_resources\` boolean on \`Screen\` to back the MA "Disability Resources" tile. This PR wires the FE side so the tile selection round-trips through the API. Without this PR, picking the tile is a no-op.

## Changes Made

- \`src/Types/ApiFormData.ts\`: add \`needs_disability_resources: boolean | null\` to \`ApiFormData\`.
- \`src/Assets/updateScreen.ts\`: map \`formData.acuteHHConditions.disabilityResources\` to the API field on submit.
- \`src/Assets/updateFormData.tsx\`: read \`response.needs_disability_resources\` back into \`acuteHHConditions.disabilityResources\` when hydrating form state.

The tile itself is rendered automatically by \`ImmediateNeeds.tsx\` from the \`acute_condition_options\` config — no FE component change needed once the MA config (in the backend PR) defines the \`disabilityResources\` entry.

## Testing

- Migrations to run: n/a (FE-only)
- Configuration updates needed: backend PR must be deployed first so the MA \`acute_condition_options\` config includes the new tile.
- Environment variables/settings to add: none
- Manual testing steps:
  1. Point local FE at a backend that has #1542 merged + \`add_config ma\` + \`import_urgent_need_config .../ma_able_account.json\` run.
  2. Start a fresh MA screen.
  3. On the Additional Resources step, confirm the new **Resources for people with disabilities** tile renders (wheelchair icon).
  4. Select it, finish the wizard, and confirm **Attainable® Savings Plan (ABLE Account)** appears in results.
  5. Restart, do *not* select the tile, and confirm the ABLE Account is hidden.
  6. Reload an in-progress screen with the tile previously selected — confirm the tile shows as selected (hydration via \`updateFormData\`).

## Deployment

- Run script: none
- Update production config: none
- Admin updates needed: none
- Notify team/users of: ship after the backend PR is in prod (otherwise the API will 400 on the unknown field… actually DRF will just ignore it, but the tile won't appear without the config update).

## Notes for Reviewers

- Mirrors the existing pattern for the other ten \`needs_*\` fields one-for-one — three single-line additions.
- Known limitations: until the backend PR's \`add_config ma\` runs in each environment, the tile won't render. Cosmetic-only; no errors.
- Future considerations: if more states adopt disability tiles, no further FE changes needed — they just add their own \`disabilityResources\` entry to their white_label's \`acute_condition_options\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)