### PR TITLE
MFB-1085: Toggle sibling benefit variants together on step 8 deselect

### DIFF
--- a/src/Assets/benefitSiblings.test.ts
+++ b/src/Assets/benefitSiblings.test.ts
@@ -1,0 +1,38 @@
+import { getBenefitSiblings, BENEFIT_SIBLING_GROUPS } from './benefitSiblings';
+
+describe('getBenefitSiblings', () => {
+  it('returns all variants for a key that is part of a sibling group', () => {
+    expect(getBenefitSiblings('co_snap')).toEqual([
+      'snap',
+      'co_snap',
+      'il_snap',
+      'ma_snap',
+      'nc_snap',
+      'tx_snap',
+      'cesn_snap',
+    ]);
+  });
+
+  it('returns the same group regardless of which variant in the group is queried', () => {
+    expect(getBenefitSiblings('snap')).toEqual(getBenefitSiblings('cesn_snap'));
+  });
+
+  it('returns the single-key fallback for keys not in any group', () => {
+    expect(getBenefitSiblings('medicaid')).toEqual(['medicaid']);
+    expect(getBenefitSiblings('eitc')).toEqual(['eitc']);
+  });
+
+  it('returns the single-key fallback for unknown keys', () => {
+    expect(getBenefitSiblings('not_a_real_benefit')).toEqual(['not_a_real_benefit']);
+  });
+
+  it('exposes BENEFIT_SIBLING_GROUPS with no overlapping keys across groups', () => {
+    const seen = new Set<string>();
+    for (const group of BENEFIT_SIBLING_GROUPS) {
+      for (const key of group) {
+        expect(seen.has(key)).toBe(false);
+        seen.add(key);
+      }
+    }
+  });
+});

--- a/src/Assets/benefitSiblings.ts
+++ b/src/Assets/benefitSiblings.ts
@@ -1,0 +1,49 @@
+/**
+ * Variant keys that share the same has_* column on the backend Screen model.
+ *
+ * Background: the backend stores one boolean per benefit (e.g. `has_snap`),
+ * but the frontend `formData.benefits` map has multiple keys pointing at the
+ * same column (e.g. `snap`, `co_snap`, `il_snap` all hydrate from
+ * `response.has_snap` in updateFormData.tsx and all OR-merge into `has_snap`
+ * in updateScreen.ts).
+ *
+ * Step 8 (AlreadyHasBenefits) only renders ONE tile per has_* column — the
+ * white-label-specific variant returned by the hasBenefitsPrograms endpoint.
+ * Without sibling tracking, toggling that one tile only flipped one key while
+ * the stale sibling kept the OR-chain `true`, so deselect never persisted.
+ * See MFB-1085 for the full bug trace.
+ *
+ * Each entry below is a sibling group: any key in the group, when toggled,
+ * should toggle every other key in the group.
+ *
+ * Sourced from the OR-chains in `getScreensBody` (updateScreen.ts). If a new
+ * variant is added there, add it here too.
+ *
+ * All of this disappears in MFB-720 when the join-table migration completes
+ * and `formData.benefits` keys mirror `name_abbreviated` 1:1.
+ */
+export const BENEFIT_SIBLING_GROUPS: ReadonlyArray<ReadonlyArray<string>> = [
+  ['ccap', 'il_ccap', 'nc_cccap'],
+  ['leap', 'nc_leap'],
+  ['oap', 'cesn_oap'],
+  ['rtdlive', 'cesn_rtdlive'],
+  ['snap', 'co_snap', 'il_snap', 'ma_snap', 'nc_snap', 'tx_snap', 'cesn_snap'],
+  ['ssdi', 'tx_ssdi', 'cesn_ssdi'],
+  ['ssi', 'tx_ssi', 'cesn_ssi'],
+  ['cowap', 'cesn_cowap'],
+  ['tanf', 'co_tanf', 'il_tanf', 'nc_tanf', 'tx_tanf', 'cesn_tanf'],
+  ['wic', 'co_wic', 'il_wic', 'ma_wic', 'nc_wic', 'tx_wic', 'cesn_wic'],
+  ['section_8', 'co_section_8', 'ma_section_8', 'cesn_section_8'],
+  ['aca', 'nc_aca'],
+  ['co_andso', 'cesn_andso'],
+  ['co_care', 'cesn_care'],
+];
+
+/**
+ * Returns every key (including the input) that should be toggled together
+ * with `key`. For keys not in any sibling group, returns `[key]`.
+ */
+export function getBenefitSiblings(key: string): readonly string[] {
+  const group = BENEFIT_SIBLING_GROUPS.find((g) => g.includes(key));
+  return group ?? [key];
+}

--- a/src/Components/Steps/AlreadyHasBenefits.tsx
+++ b/src/Components/Steps/AlreadyHasBenefits.tsx
@@ -5,6 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import type { HasBenefitsProgram } from '../../Types/ApiCalls';
 import useScreenApi from '../../Assets/updateScreen';
+import { getBenefitSiblings } from '../../Assets/benefitSiblings';
 import { OverrideableTranslation } from '../../Assets/languageOptions';
 import HasBenefitsTile from './HasBenefitsTile';
 import PrevAndContinueButtons from '../PrevAndContinueButtons/PrevAndContinueButtons';
@@ -163,9 +164,18 @@ function AlreadyHasBenefits() {
                   program={program}
                   selected={!!alreadyHasBenefits[key]}
                   onClick={() => {
+                    // Multiple formData.benefits keys share one has_* column on
+                    // the backend (e.g. 'snap' and 'co_snap' both map to
+                    // has_snap). Step 8 only shows ONE tile per column, so we
+                    // must flip every sibling together — otherwise the unshown
+                    // siblings keep their stale value and updateScreen's OR-chain
+                    // re-asserts has_*=true on deselect. See MFB-1085.
+                    const newValue = !alreadyHasBenefits[key];
+                    const siblings = getBenefitSiblings(key);
+                    const updates = Object.fromEntries(siblings.map((s) => [s, newValue]));
                     setValue(
                       'alreadyHasBenefits',
-                      { ...alreadyHasBenefits, [key]: !alreadyHasBenefits[key] },
+                      { ...alreadyHasBenefits, ...updates },
                       { shouldDirty: true, shouldTouch: true },
                     );
                   }}


### PR DESCRIPTION
## Context & Motivation

On step 8 (\"Current Household Benefits\"), deselecting a benefit the user previously selected did not persist. The PATCH/PUT to `/api/screens/<uuid>/` re-sent `has_<benefit>: true`, so the backend correctly stored what it was told — but the user's intent (revoke the benefit) was silently lost.

Surfaced during manual QA of [MFB-719](https://linear.app/myfriendben/issue/MFB-719) (the join-table read-flip in benefits-api). The read-flip works correctly given accurate input; this bug is upstream of that change.

Linear: [MFB-1085](https://linear.app/myfriendben/issue/MFB-1085/step-8-deselection-of-current-benefits-doesnt-persist-patch-sends)

### Root cause

`formData.benefits` has multiple keys pointing at the same backend `has_*` column (e.g. `snap`, `co_snap`, `il_snap`, `ma_snap`, etc. all hydrate from `response.has_snap` in `updateFormData.tsx` and all OR-merge back into `has_snap` in `updateScreen.ts`'s `getScreensBody`).

Step 8 renders only ONE tile per `has_*` column — the WL-specific variant returned by `hasBenefitsPrograms`. The tile's `onClick` handler toggled only that one key. The federal/sibling keys kept their stale `true` value from the read, and the OR-chain in `getScreensBody` re-asserted `has_*: true` on the next PUT. Deselect never converged.

Concrete trace for a CO white-label screen with SNAP previously selected:
1. Backend: `has_snap = true`
2. `updateFormData` hydrates `formData.benefits.snap = true` AND `formData.benefits.co_snap = true`
3. Step 8 displays one CO SNAP tile (selected) — keyed on `co_snap`
4. User deselects → `formData.benefits.co_snap = false` (only that key flips)
5. `getScreensBody`: `has_snap: formData.benefits.snap || formData.benefits.co_snap || ... || null` = `true || false || ... = true`
6. PUT sends `has_snap: true` ❌

## Changes Made

- New `src/Assets/benefitSiblings.ts` — single source of truth for variant groups, derived from the existing OR-chains in `getScreensBody`. Exports `BENEFIT_SIBLING_GROUPS` and `getBenefitSiblings(key)`.
- `AlreadyHasBenefits.tsx` tile `onClick` now flips every sibling variant together via `getBenefitSiblings(key)`. A non-sibling key (e.g. `medicaid`) still only flips itself.
- Unit test for `getBenefitSiblings` covering: sibling lookup, symmetry, non-sibling fallback, unknown-key fallback, and a structural invariant that no key appears in two groups.

Intentionally narrow: this does NOT touch `updateFormData.tsx` (fan-out on read stays) or the OR-chains in `updateScreen.ts` (write-side merge stays). The fix is localized to the toggle handler so the blast radius is contained to step 8.

All of this disappears in MFB-720 when the join-table migration completes and `formData.benefits` keys mirror `name_abbreviated` 1:1 — flagged in the new file's docstring.

## Testing

- Migrations to run: none
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  1. Start a new screen on CO. On step 8, check SNAP. Advance to confirmation → SNAP listed. ✅
  2. Go back to step 8 via edit pencil → SNAP shows as checked. Deselect it. Continue. → confirmation no longer lists SNAP. ✅
  3. Re-enter step 8 via edit pencil → checkbox is unchecked. ✅
  4. DevTools Network tab on the deselect-then-Continue → PUT body shows `has_snap: null` (not `true`).
  5. Re-select SNAP, advance, then go back and deselect a different benefit (e.g. TANF) → only the deselected benefit clears in the response; SNAP remains.

## Deployment

- Run script: none
- Update production config: none
- Admin updates needed: none
- Notify team/users of: nothing user-visible beyond the bug being fixed.

## Notes for Reviewers

- The sibling-group list is sourced from the existing OR-chains in `updateScreen.ts`. If a new variant is added there (e.g. a new WL adds `xx_snap`), it must be added to `BENEFIT_SIBLING_GROUPS` too. The docstring calls this out.
- Considered fixing on the read side (only hydrate the WL-specific key) but that would require knowing the active WL at hydrate time and could break the results page or other consumers that read non-WL keys. Toggle-side is lower blast radius.
- Considered rewriting the OR-chain in `getScreensBody` but it doesn't solve the bug alone — if `snap=true` is stale from read and `co_snap=false` is the deselect, \"any variant is true\" still wins.
- Known limitations: a hypothetical user on white label A whose `formData.benefits` was loaded on white label B will still see odd behavior because the keys diverged across sessions, but this isn't a real flow.
- Future considerations: MFB-720 deletes `formData.benefits` variant keys, this file, and the OR-chains all at once. No migration path needed — just delete.