### PR TITLE
ci: up workers and retry failed Playwright tests twice on CI to absorb flakes

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   workers: process.env.CI ? 1 : undefined,
+  /* On CI, retry failed tests up to twice to absorb infra/network flakes
+     (mid-spec dev-server hiccups, slow first-paint timeouts, etc.). Real
+     failures cost extra wallclock but pass-on-retry saves a full re-run. */
+  retries: process.env.CI ? 2 : 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [['html'], ['json', { outputFile: 'results.json' }], ['list']],
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,13 @@ export default defineConfig({
   fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  workers: process.env.CI ? 1 : undefined,
+  /* On CI, run 3 workers in parallel. Tests are well-isolated (fresh browser
+     context per test, no shared fixtures, no shared screen UUIDs), so the
+     speedup is bounded by file count (9) and the two long-pole files
+     (white-labels.spec.ts, current-benefits.spec.ts) that loop over white
+     labels. fullyParallel stays false — files run in parallel, tests within
+     a file remain serial. */
+  workers: process.env.CI ? 3 : undefined,
   /* On CI, retry failed tests up to twice to absorb infra/network flakes
      (mid-spec dev-server hiccups, slow first-paint timeouts, etc.). Real
      failures cost extra wallclock but pass-on-retry saves a full re-run. */


### PR DESCRIPTION
## Context & Motivation

Playwright e2e CI has been hit by a persistent low-grade flake problem — failures on pre-step-1 elements (landing-page Get Started button timeouts, current-benefits page rendering, referrer-param persistence). Manual reruns of the full ~9-minute suite are slow and don't always converge.

This PR makes two complementary CI-only changes:

1. **Retry failed tests twice in-band** so individual flake-failures don't require a full workflow rerun.
2. **Parallelize across 3 workers** so the full suite wallclock drops without changing the rerun model.

Surfaced during CI runs on [PR #2113](https://github.com/MyFriendBen/benefits-calculator/pull/2113) (MFB-1085). Same pattern previously hit `mfb-979-calculate-impact-shell` and others — two consecutive failures before a clean pass.

## Changes Made

`playwright.config.ts` (CI-only — local dev runs unaffected):

- `retries: process.env.CI ? 2 : 0` — failed tests retry up to twice.
- `workers: process.env.CI ? 3 : undefined` — 3 parallel workers (was 1).
- `fullyParallel: false` stays — files run in parallel, tests within a file remain serial. Safer parallelization story.

## Why 3 workers is safe

Audited before bumping:

- **No shared screen UUIDs** — each test creates its own screen via the wizard.
- **No `beforeAll` fixtures or global setup** that share state across tests.
- **No `globalSetup`** wiring.
- **Per-test browser context** (Playwright default) — fresh cookies/storage per test.
- The only `beforeEach` (in `google-translate-prevention.spec.ts`) creates a fresh `BrowserContext` per test — parallel-safe.
- **9 spec files** total. 3 workers → 3 files per worker, even load.
- **GH Actions `ubuntu-latest`**: 4 vCPUs / 16GB RAM. 3 chromium + dev server + Node fits comfortably.

## Testing

- Migrations to run: none
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  1. Open this PR — Playwright job runs. Verify total wallclock drops meaningfully from ~9 min (worker count visible in the report).
  2. Confirm flake-prone tests now show as `flaky` (passed-on-retry) rather than `failed` when infra hiccups.
  3. Run `npm run test:e2e` locally — retries do NOT apply, workers default to undefined (Playwright picks based on CPU). No local change.

## Deployment

- Run script: none
- Update production config: none
- Admin updates needed: none
- Notify team/users of: nothing user-visible. Internal CI hygiene only.

## Notes for Reviewers

- Standard Playwright pattern: `retries: process.env.CI ? 2 : 0` (see https://playwright.dev/docs/test-retries).
- Cost on a real (non-flake) failure: that test runs up to 3 times before reporting. Adds ~30s per failing test in the worst case. Acceptable given the alternative is a full ~9-minute rerun.
- 3 workers chosen over 2 because file distribution favors it — two long-pole files (`white-labels.spec.ts`, `current-benefits.spec.ts`) dominate wallclock and run serially within themselves. A third worker chews through the remaining 7 short files in parallel.

### Known limitations & rollback

- Retries mask flakes rather than fixing them. Underlying landing-page timeout and current-benefits placeholder tests should still be triaged separately if retries become routinely necessary.
- If `workers: 3` surfaces new flakes that didn't exist at `workers: 1`, the rollback is a one-line revert with no data/coordination cost. Watch for: same test failing across multiple PRs in a row, or `Flaky` count jumping noticeably per run.

### Future considerations

- If 3 stays clean over a few PR cycles, room to bump higher exists (4 is the practical ceiling on this runner).
- `fullyParallel: true` is a bigger semantic change — would require per-test isolation audit — and is intentionally deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI test execution with increased worker parallelism and automatic retry logic for improved pipeline reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/benefits-calculator/pull/2114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->