### PR TITLE
MFB-979: Fix calculate-impact form overflow with longer localized strings

### DIFF
--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.css
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.css
@@ -103,7 +103,10 @@
 /* Two-column grid — left column narrower, right wider */
 .calculate-impact-page .calculate-impact-fields-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  /* minmax(0, 1fr) lets the columns shrink below their content's intrinsic width
+     (the default min-width: auto would let long labels/placeholders — e.g. the
+     longer Spanish strings — push the grid past the card edge). */
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   column-gap: 1.5rem;
   row-gap: 0.5rem;
   margin-bottom: 1rem;
@@ -112,6 +115,8 @@
 .calculate-impact-page .calculate-impact-fields-grid > .calculate-impact-field {
   display: flex;
   flex-direction: column;
+  /* Allow the flex item to shrink so its contents (selects/inputs) don't force overflow. */
+  min-width: 0;
 }
 
 /* Push input to the bottom of the field so inputs align across columns regardless of helper text height */
@@ -131,6 +136,16 @@
   margin-top: auto;
   position: relative;
   margin-bottom: 0.75rem;
+}
+
+/* Truncate the selected value / placeholder inside the select so a long localized
+   string (e.g. Spanish "Seleccione el combustible para calefacción...") ellipsizes
+   instead of widening the column and overflowing the card. */
+.calculate-impact-page .calculate-impact-fields-grid .MuiSelect-select,
+.calculate-impact-page .calculate-impact-fields-grid .calculate-impact-select-placeholder {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 @media (max-width: 767px) {
@@ -250,7 +265,9 @@
   color: #555;
   margin: 0 0 0.4rem;
   line-height: 1.4;
-  white-space: nowrap;
+  /* Must wrap: localized helper text (e.g. Spanish) is longer than the English
+     original and would overflow the card if forced onto a single line. */
+  overflow-wrap: break-word;
 }
 
 /* Radio options with descriptions */


### PR DESCRIPTION
## Context & Motivation

Follow-up to MFB-979. When viewing the Calculate Impact page in **Spanish** (and other languages with longer strings than English), the household-info input boxes overflowed the right edge of the gray card. English fit by luck; the longer localized labels/placeholders/helper text exposed the layout bug.

Found while seeding the MFB-978/979 translations into staging — the English page looked fine, Spanish did not.

## Changes Made

All in `CalculateImpactPage.css`, scoped to the fields grid:

* **Grid tracks `1fr 1fr` → `minmax(0, 1fr) minmax(0, 1fr)`** + `min-width: 0` on the field items. CSS grid tracks default to `min-width: auto`, so a `1fr` column won't shrink below its content's intrinsic width — long Spanish strings pushed the grid past the card. `minmax(0, 1fr)` lets the columns shrink.
* **Field helper: removed `white-space: nowrap` → `overflow-wrap: break-word`.** The Spanish water-heating helper sentence was forced onto one unbreakable line, far wider than the card.
* **Select value/placeholder ellipsis-truncation.** A long localized placeholder (e.g. "Seleccione el combustible para calefacción...") now ellipsizes instead of widening its column.

English layout is unchanged — this only makes the layout robust to longer translated strings.

## Testing

* Verified locally in **Spanish and English** (after seeding the heat-pump-journey translations into the local DB): boxes stay within the card, helper text wraps, placeholders truncate.
* Spot-checked desktop / tablet (≤767px) / mobile (≤480px) breakpoints — existing single-column mobile layout unaffected.

Fixes the localized-overflow issue on MFB-979.

Linear: https://linear.app/myfriendben/issue/MFB-979

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout responsiveness to better accommodate localized and extended text strings within forms and cards.
  * Enhanced text display with automatic truncation and word wrapping to prevent content overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->