### PR TITLE
MFB-1110: Wire cesn_medicaid has-benefits tile to has_medicaid

### DIFF
--- a/src/Assets/benefitSiblings.test.ts
+++ b/src/Assets/benefitSiblings.test.ts
@@ -18,8 +18,12 @@ describe('getBenefitSiblings', () => {
     expect(getBenefitSiblings('snap')).toEqual(getBenefitSiblings('cesn_snap'));
   });
 
+  it('groups medicaid with its CESN variant', () => {
+    expect(getBenefitSiblings('medicaid')).toEqual(['medicaid', 'cesn_medicaid']);
+    expect(getBenefitSiblings('cesn_medicaid')).toEqual(getBenefitSiblings('medicaid'));
+  });
+
   it('returns the single-key fallback for keys not in any group', () => {
-    expect(getBenefitSiblings('medicaid')).toEqual(['medicaid']);
     expect(getBenefitSiblings('lifeline')).toEqual(['lifeline']);
   });
 

--- a/src/Assets/benefitSiblings.ts
+++ b/src/Assets/benefitSiblings.ts
@@ -37,6 +37,7 @@ export const BENEFIT_SIBLING_GROUPS: ReadonlyArray<ReadonlyArray<string>> = [
   ['aca', 'nc_aca'],
   ['co_andso', 'cesn_andso'],
   ['co_care', 'cesn_care'],
+  ['medicaid', 'cesn_medicaid'],
   ['eitc', 'wa_eitc'],
   ['nslp', 'wa_nslp'],
   ['head_start', 'wa_head_start'],

--- a/src/Assets/updateFormData.tsx
+++ b/src/Assets/updateFormData.tsx
@@ -102,6 +102,7 @@ export function useUpdateFormData() {
         wa_hcv: response.has_section_8 ?? false,
         chp: response.has_chp ?? false,
         medicaid: response.has_medicaid ?? false,
+        cesn_medicaid: response.has_medicaid ?? false,
         ccap: response.has_ccap ?? false,
         il_ccap: response.has_ccap ?? false,
         nc_cccap: response.has_ccap ?? false,
@@ -259,7 +260,7 @@ export function useUpdateFormData() {
       updatedFormData.expenses.push({
         expenseSourceName: expense.type ?? '',
         expenseAmount: Math.round(parseFloat(String(expense.amount ?? 0)) || 0),
-        expenseFrequency: (expense.frequency === 'yearly' ? 'yearly' : 'monthly'),
+        expenseFrequency: expense.frequency === 'yearly' ? 'yearly' : 'monthly',
       });
     }
 

--- a/src/Assets/updateScreen.ts
+++ b/src/Assets/updateScreen.ts
@@ -52,7 +52,12 @@ const getScreensBody = (formData: FormData, languageCode: Language, whiteLabel: 
     has_il_bap: formData.benefits.il_bap ?? null,
     has_il_hbwd: formData.benefits.il_hbwd ?? null,
     has_csfp: formData.benefits.csfp ?? null,
-    has_ccap: formData.benefits.ccap || formData.benefits.il_ccap || formData.benefits.nc_cccap || formData.benefits.cccap || null,
+    has_ccap:
+      formData.benefits.ccap ||
+      formData.benefits.il_ccap ||
+      formData.benefits.nc_cccap ||
+      formData.benefits.cccap ||
+      null,
     has_erc: null,
     has_lifeline: formData.benefits.lifeline ?? null,
     has_leap: formData.benefits.leap || formData.benefits.nc_leap || formData.benefits.cesn_leap || null,
@@ -63,20 +68,62 @@ const getScreensBody = (formData: FormData, languageCode: Language, whiteLabel: 
     has_pell_grant: formData.benefits.pell ?? null,
     has_nfp: formData.benefits.nfp ?? null,
     has_rtdlive: formData.benefits.rtdlive || formData.benefits.cesn_rtdlive || null,
-    has_snap: formData.benefits.snap || formData.benefits.co_snap || formData.benefits.il_snap || formData.benefits.ma_snap || formData.benefits.nc_snap || formData.benefits.tx_snap || formData.benefits.cesn_snap || formData.benefits.wa_snap || null,
+    has_snap:
+      formData.benefits.snap ||
+      formData.benefits.co_snap ||
+      formData.benefits.il_snap ||
+      formData.benefits.ma_snap ||
+      formData.benefits.nc_snap ||
+      formData.benefits.tx_snap ||
+      formData.benefits.cesn_snap ||
+      formData.benefits.wa_snap ||
+      null,
     has_sunbucks: formData.benefits.sunbucks ?? null,
-    has_ssdi: formData.benefits.ssdi || formData.benefits.tx_ssdi || formData.benefits.cesn_ssdi || formData.benefits.wa_ssdi || null,
-    has_ssi: formData.benefits.ssi || formData.benefits.tx_ssi || formData.benefits.cesn_ssi || formData.benefits.wa_ssi || null,
+    has_ssdi:
+      formData.benefits.ssdi ||
+      formData.benefits.tx_ssdi ||
+      formData.benefits.cesn_ssdi ||
+      formData.benefits.wa_ssdi ||
+      null,
+    has_ssi:
+      formData.benefits.ssi ||
+      formData.benefits.tx_ssi ||
+      formData.benefits.cesn_ssi ||
+      formData.benefits.wa_ssi ||
+      null,
     has_cowap: formData.benefits.cowap || formData.benefits.cesn_cowap || null,
     has_ubp: formData.benefits.ubp ?? null,
-    has_tanf: formData.benefits.tanf || formData.benefits.co_tanf || formData.benefits.il_tanf || formData.benefits.nc_tanf || formData.benefits.tx_tanf || formData.benefits.cesn_tanf || formData.benefits.wa_tanf || null,
-    has_wic: formData.benefits.wic || formData.benefits.co_wic || formData.benefits.il_wic || formData.benefits.ma_wic || formData.benefits.nc_wic || formData.benefits.tx_wic || formData.benefits.cesn_wic || formData.benefits.wa_wic || null,
+    has_tanf:
+      formData.benefits.tanf ||
+      formData.benefits.co_tanf ||
+      formData.benefits.il_tanf ||
+      formData.benefits.nc_tanf ||
+      formData.benefits.tx_tanf ||
+      formData.benefits.cesn_tanf ||
+      formData.benefits.wa_tanf ||
+      null,
+    has_wic:
+      formData.benefits.wic ||
+      formData.benefits.co_wic ||
+      formData.benefits.il_wic ||
+      formData.benefits.ma_wic ||
+      formData.benefits.nc_wic ||
+      formData.benefits.tx_wic ||
+      formData.benefits.cesn_wic ||
+      formData.benefits.wa_wic ||
+      null,
     has_upk: formData.benefits.upk ?? null,
     has_coctc: formData.benefits.coctc ?? null,
     has_fatc: formData.benefits.fatc ?? null,
-    has_section_8: formData.benefits.section_8 || formData.benefits.co_section_8 || formData.benefits.ma_section_8 || formData.benefits.cesn_section_8 || formData.benefits.wa_hcv || null,
+    has_section_8:
+      formData.benefits.section_8 ||
+      formData.benefits.co_section_8 ||
+      formData.benefits.ma_section_8 ||
+      formData.benefits.cesn_section_8 ||
+      formData.benefits.wa_hcv ||
+      null,
     has_chp: formData.benefits.chp ?? null,
-    has_medicaid: formData.benefits.medicaid ?? null,
+    has_medicaid: formData.benefits.medicaid || formData.benefits.cesn_medicaid || null,
     has_nc_medicare_savings: formData.benefits.nc_medicare_savings ?? null,
     has_nc_lieap: formData.benefits.nc_lieap ?? null,
     has_ncwap: formData.benefits.ncwap ?? null,


### PR DESCRIPTION
## Context & Motivation

Frontend half of MFB-1110. A CESN partner asked why Medicaid isn't in CESN's "already has benefits" list. CESN does not collect health insurance, so the member-level Medicaid check that drives presumptive eligibility for Utility Bill Pay (`cesn_ubp`) never fires. The fix is to let CESN capture Medicaid at the **household level** via the already-has step, which sets `Screen.has_medicaid` and drives `cesn_ubp` presumptive eligibility.

The backend re-adds a `cesn_medicaid` tracking-only program (it was deleted in migration 0143) and adds `"medicaid"` to the CESN UBP household presumptive set. This PR wires the new `cesn_medicaid` has-benefits tile through to the shared `has_medicaid` column.

- Related PR (backend): MyFriendBen/benefits-api#1558
- Linear: MFB-1110

## Changes Made

Mirrors how existing CESN variants (`cesn_oap`, `cesn_section_8`, `cesn_care`) are wired to their shared `has_*` columns:

- `src/Assets/updateScreen.ts` — OR `cesn_medicaid` into `has_medicaid` on write.
- `src/Assets/updateFormData.tsx` — hydrate `cesn_medicaid` from `response.has_medicaid` on read (so a saved selection re-displays).
- `src/Assets/benefitSiblings.ts` — add sibling group `['medicaid', 'cesn_medicaid']` so toggling the single rendered tile flips both keys and deselect persists (MFB-1085 OR-chain bug).
- `src/Assets/benefitSiblings.test.ts` — update the `medicaid` case to expect the new group.

## Testing

- Migrations to run: none in FE. Backend PR #1558 adds migration 0157 (re-creates `cesn_medicaid`).
- Configuration updates needed: none beyond the backend program re-add (the tile is data-driven from `getHasBenefitsPrograms`).
- Environment variables/settings to add: none
- Manual testing steps:
  - `npm test -- src/Assets/benefitSiblings.test.ts` (passes)
  - `npm run lint` (clean)
  - With backend PR deployed, on a CESN screen confirm a "Health First Colorado (Medicaid)" tile appears on the already-has step; selecting it then completing the screen yields Utility Bill Pay as eligible (income test skipped). Deselect persists across navigation.

## Deployment

- Run script: deploy backend PR #1558 first (migration creates the `cesn_medicaid` program); this FE depends on that tile existing.
- Update production config: none beyond the backend migration
- Admin updates needed: none
- Notify team/users of: CESN partner who raised the question

## Notes for Reviewers

- Known limitations: only regular Medicaid is captured at the household level for CESN; CHP+ / Emergency Medicaid remain member-level-only and have no household field (`cesn_chp` is intentionally not re-added).
- Future considerations: MFB-720 (join-table migration) will make `formData.benefits` keys mirror `name_abbreviated` 1:1 and retire `benefitSiblings` + the OR-chains; this group goes away with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)