### PR TITLE
MFB-981: Heat Pump Step 3 - Wire Rewiring America API + EPA equivalencies for heat pump water heater

### DIFF
--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.css
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.css
@@ -307,6 +307,239 @@
   margin-top: 1.25rem;
 }
 
+/* ── "Coming soon" badge on disabled upgrade options ── */
+.calculate-impact-page .calculate-impact-coming-soon {
+  font-size: 0.72rem;
+  font-weight: 400;
+  font-style: italic;
+  color: #777;
+  margin-left: 0.5rem;
+}
+
+.calculate-impact-page .calculate-impact-radio-option[data-disabled='true'] {
+  opacity: 0.55;
+  cursor: default;
+}
+
+/* ── Loading / error states ── */
+.calculate-impact-page .calculate-impact-loading {
+  display: flex;
+  justify-content: center;
+  padding: 1.5rem 0;
+}
+
+.calculate-impact-page .calculate-impact-error {
+  margin-bottom: 1rem;
+}
+
+/* ── Results view ── */
+.calculate-impact-results {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* Summary card header row (title + pencil icon) */
+.calculate-impact-summary-card .calculate-impact-summary-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.calculate-impact-summary-card .calculate-impact-edit-btn {
+  color: var(--secondary-color, #001970);
+}
+
+/* Summary field list */
+.calculate-impact-summary-fields {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.calculate-impact-summary-field {
+  display: flex;
+  gap: 0.35rem;
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: #333;
+}
+
+.calculate-impact-summary-field dt {
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.calculate-impact-summary-field dt::after {
+  content: ':';
+}
+
+.calculate-impact-summary-field dd {
+  margin: 0;
+}
+
+/* Selected upgrade row */
+.calculate-impact-selected-upgrade {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.calculate-impact-upgrade-value {
+  background-color: #f0f2f5;
+  border-radius: 0.375rem;
+  padding: 0.6rem 0.9rem;
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  color: #333;
+}
+
+/* Bill + emissions impact card subsections */
+.calculate-impact-impact-section {
+  margin-top: 1.25rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid #d6d8dc;
+}
+
+.calculate-impact-impact-section:first-of-type {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: none;
+}
+
+.calculate-impact-impact-title {
+  font-family: var(--font-body);
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #111;
+  margin: 0 0 0.4rem;
+}
+
+.calculate-impact-impact-description {
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  color: #444;
+  line-height: 1.55;
+  margin: 0 0 1rem;
+}
+
+/* ── Range bar ── */
+.impact-range-bar {
+  margin: 0.5rem 0 1rem;
+}
+
+.impact-range-bar__median-wrapper {
+  position: relative;
+  height: 2.75rem;
+  margin-bottom: 0.1rem;
+}
+
+.impact-range-bar__median-float {
+  position: absolute;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.impact-range-bar__median-value {
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #111;
+  background: #e8ecf5;
+  border-radius: 0.25rem;
+  padding: 0.15rem 0.4rem;
+  line-height: 1.4;
+}
+
+.impact-range-bar__median-caret {
+  font-size: 0.7rem;
+  color: #444;
+  line-height: 1;
+  margin-top: 0.1rem;
+}
+
+.impact-range-bar__track {
+  position: relative;
+  height: 10px;
+  border-radius: 5px;
+  background: #d9dde6;
+  overflow: hidden;
+}
+
+.impact-range-bar__fill {
+  position: absolute;
+  top: 0;
+  height: 100%;
+}
+
+.impact-range-bar__fill--savings {
+  background-color: #388e3c;
+}
+
+.impact-range-bar__fill--increase {
+  background-color: #d32f2f;
+}
+
+.impact-range-bar__end-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.3rem;
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+}
+
+.impact-range-bar__label--savings {
+  color: #2e7d32;
+}
+
+.impact-range-bar__label--increase {
+  color: #c62828;
+}
+
+/* ── EPA equivalencies ── */
+.calculate-impact-epa-section {
+  margin-top: 1rem;
+}
+
+.calculate-impact-epa-intro {
+  font-family: var(--font-body);
+  font-size: 0.88rem;
+  color: #555;
+  margin: 0 0 0.5rem;
+}
+
+.calculate-impact-epa-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.calculate-impact-epa-chip.MuiChip-root {
+  background-color: #e0e8e0;
+  color: #1b5e20;
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+}
+
+.calculate-impact-epa-chip .MuiChip-icon {
+  color: #2e7d32;
+}
+
+.calculate-impact-epa-source {
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  color: #777;
+  margin: 0;
+}
+
 /* Form inputs sit on white inside the grey card */
 .calculate-impact-page .MuiOutlinedInput-root {
   background-color: #fff;

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.css
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.css
@@ -86,7 +86,7 @@
 /* Section titles (h2) */
 .calculate-impact-page .calculate-impact-section-title {
   font-family: var(--font-body);
-  font-size: 1.25rem;
+  font-size: 1rem;
   font-weight: 700;
   color: var(--secondary-color, #001970);
   margin: 0 0 0.4rem;
@@ -94,7 +94,8 @@
 
 .calculate-impact-page .calculate-impact-section-description {
   font-family: var(--font-body);
-  font-size: 0.95rem;
+  font-size: 0.875rem;
+  font-weight: 400;
   color: #333;
   margin: 0 0 1.25rem;
   line-height: 1.5;
@@ -332,11 +333,17 @@
   margin-bottom: 1rem;
 }
 
-/* ── Results view ── */
-.calculate-impact-results {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
+/* ── Results outer card (single black border, white background) ── */
+.calculate-impact-results-outer-card {
+  border: 1.5px solid #111;
+  border-radius: 0.5rem;
+  background-color: #fff;
+  overflow: hidden;
+}
+
+/* Summary section (household info) */
+.calculate-impact-summary-card {
+  padding: 1.25rem 1.5rem;
 }
 
 /* Summary card header row (title + pencil icon) */
@@ -387,18 +394,30 @@
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
+  padding: 0.75rem 1.5rem 0;
 }
 
+/* Value spans edge-to-edge inside the outer card */
 .calculate-impact-upgrade-value {
   background-color: #f0f2f5;
-  border-radius: 0.375rem;
-  padding: 0.6rem 0.9rem;
+  padding: 0.6rem 1.5rem;
+  margin: 0 -1.5rem;
   font-family: var(--font-body);
   font-size: 0.95rem;
   color: #333;
 }
 
-/* Bill + emissions impact card subsections */
+/* Bill and emissions section — header + intro at card padding, subsections indented */
+.calculate-impact-bill-emissions-section {
+  padding: 1.25rem 1.5rem;
+}
+
+/* Indented subsections (Energy bill impact, Emissions impact) */
+.calculate-impact-impact-indented {
+  padding-left: 1.25rem;
+  margin-top: 0.75rem;
+}
+
 .calculate-impact-impact-section {
   margin-top: 1.25rem;
   padding-top: 1.25rem;
@@ -413,7 +432,7 @@
 
 .calculate-impact-impact-title {
   font-family: var(--font-body);
-  font-size: 1.05rem;
+  font-size: 0.95rem;
   font-weight: 700;
   color: #111;
   margin: 0 0 0.4rem;
@@ -421,7 +440,8 @@
 
 .calculate-impact-impact-description {
   font-family: var(--font-body);
-  font-size: 0.9rem;
+  font-size: 0.875rem;
+  font-weight: 400;
   color: #444;
   line-height: 1.55;
   margin: 0 0 1rem;
@@ -438,8 +458,10 @@
   margin-bottom: 0.1rem;
 }
 
+/* Median indicator — anchored to top */
 .impact-range-bar__median-float {
   position: absolute;
+  top: 0;
   transform: translateX(-50%);
   display: flex;
   flex-direction: column;
@@ -449,20 +471,39 @@
 
 .impact-range-bar__median-value {
   font-family: var(--font-body);
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   font-weight: 700;
-  color: #111;
-  background: #e8ecf5;
+  background: #e3e3e3;
   border-radius: 0.25rem;
   padding: 0.15rem 0.4rem;
   line-height: 1.4;
 }
 
 .impact-range-bar__median-caret {
-  font-size: 0.7rem;
+  font-size: 0.65rem;
   color: #444;
   line-height: 1;
   margin-top: 0.1rem;
+}
+
+/* Narrow grey capsule on the bar at the zero crossing (no text — label is below) */
+.impact-range-bar__zero-pill {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  background: #e3e3e3;
+  border-radius: 1rem;
+  width: .15rem;
+  height: 0.85rem;
+  z-index: 2;
+}
+
+/* $0 text in the end-labels row, flush with the end labels */
+.impact-range-bar__zero-label {
+  position: absolute;
+  transform: translateX(-50%);
+  color: #555;
+  font-size: 0.8rem;
 }
 
 .impact-range-bar__track {
@@ -470,7 +511,7 @@
   height: 10px;
   border-radius: 5px;
   background: #d9dde6;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .impact-range-bar__fill {
@@ -480,27 +521,56 @@
 }
 
 .impact-range-bar__fill--savings {
-  background-color: #388e3c;
+  background-color: #2e7d32;
 }
 
 .impact-range-bar__fill--increase {
-  background-color: #d32f2f;
+  background-color: #c62828;
+}
+
+/* Circle indicator at median position */
+.impact-range-bar__median-circle {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background-color: #fff;
+  border: 2px solid #555;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1;
 }
 
 .impact-range-bar__end-labels {
+  position: relative;
   display: flex;
   justify-content: space-between;
-  margin-top: 0.3rem;
+  margin-top: 0.4rem;
   font-family: var(--font-body);
   font-size: 0.8rem;
 }
 
-.impact-range-bar__label--savings {
+.impact-range-bar__end-label {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.1rem;
+}
+
+/* Arrow is colored; number is black */
+.impact-range-bar__arrow {
+  font-size: 0.75rem;
+}
+
+.impact-range-bar__arrow--savings {
   color: #2e7d32;
 }
 
-.impact-range-bar__label--increase {
+.impact-range-bar__arrow--increase {
   color: #c62828;
+}
+
+.impact-range-bar__number {
+  color: #111;
 }
 
 /* ── EPA equivalencies ── */
@@ -522,15 +592,24 @@
   margin-bottom: 0.5rem;
 }
 
-.calculate-impact-epa-chip.MuiChip-root {
-  background-color: #e0e8e0;
-  color: #1b5e20;
+/* EPA equivalency badge — styled to match the median indicator labels */
+.calculate-impact-epa-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: #e3e3e3;
+  border-radius: 0.25rem;
+  padding: 0.15rem 0.5rem;
   font-family: var(--font-body);
-  font-size: 0.85rem;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #111;
 }
 
-.calculate-impact-epa-chip .MuiChip-icon {
-  color: #2e7d32;
+.calculate-impact-epa-badge-icon {
+  font-size: 1rem !important;
+  color: #1b5e20;
+  vertical-align: middle;
 }
 
 .calculate-impact-epa-source {

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.test.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.test.tsx
@@ -194,6 +194,28 @@ describe('CalculateImpactPage', () => {
 
       expect(screen.queryByText(/please select a water heating/i)).not.toBeInTheDocument();
     });
+
+    it('shows error for water heating fuel when heat pump water heater is selected without water heating fuel', async () => {
+      renderPage();
+
+      const hpwhRadio = screen.getByRole('radio', { name: /heat pump water heater/i });
+      fireEvent.click(hpwhRadio);
+
+      const householdSelect = screen.getByRole('button', { name: /household type/i });
+      await selectOption(householdSelect, 'House');
+
+      const addressInput = screen.getByPlaceholderText('1234 Main St, Denver, CO 80014');
+      fireEvent.change(addressInput, { target: { value: '789 Pine St, Denver, CO 80202' } });
+
+      const fuelSelect = screen.getByRole('button', { name: /heating fuel/i });
+      await selectOption(fuelSelect, 'Natural gas');
+
+      fireEvent.click(screen.getByRole('button', { name: /calculate impact/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Please select a water heating fuel for this upgrade.')).toBeInTheDocument();
+      });
+    });
   });
 
   describe('form interaction', () => {

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.test.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.test.tsx
@@ -28,11 +28,24 @@ jest.mock('../../../Config/configHook', () => ({
   useFeatureFlag: jest.fn(),
 }));
 
-// Plain function (not jest.fn) so clearAllMocks() doesn't reset it.
-// Stays in loading state permanently — these tests only verify no validation errors appear.
 jest.mock('./fetchRemImpact', () => ({
-  fetchRemImpact: () => new Promise(() => {}),
+  fetchRemImpact: jest.fn(),
 }));
+
+const MOCK_RESULT = {
+  bill_delta: {
+    mean: { value: -19.76, unit: '$' },
+    median: { value: -21.91, unit: '$' },
+    percentile_20: { value: -60.52, unit: '$' },
+    percentile_80: { value: 20.50, unit: '$' },
+  },
+  emissions_delta: {
+    mean: { value: -1758.0, unit: 'lbCO2e' },
+    median: { value: -1611.7, unit: 'lbCO2e' },
+    percentile_20: { value: -2558.6, unit: 'lbCO2e' },
+    percentile_80: { value: -950.0, unit: 'lbCO2e' },
+  },
+};
 
 const renderPage = (route = '/cesn/test-uuid/results/energy-rebates/waterHeater/calculate-impact') =>
   render(
@@ -55,9 +68,9 @@ const selectOption = async (selectElement: HTMLElement, optionText: string) => {
 describe('CalculateImpactPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Re-apply after clearAllMocks resets the return value. The flag must be true
-    // for these tests — they exercise the form, not the flag-off code path.
     (jest.requireMock('../../../Config/configHook').useFeatureFlag as jest.Mock).mockReturnValue(true);
+    // Default: stays loading — most tests only exercise form state, not API results.
+    (jest.requireMock('./fetchRemImpact').fetchRemImpact as jest.Mock).mockReturnValue(new Promise(() => {}));
   });
 
   describe('rendering', () => {
@@ -250,7 +263,7 @@ describe('CalculateImpactPage', () => {
   });
 
   describe('successful form submission', () => {
-    const fillAndSubmit = async () => {
+    const fillValidForm = async () => {
       renderPage();
 
       const householdSelect = screen.getByRole('button', { name: /household type/i });
@@ -262,23 +275,54 @@ describe('CalculateImpactPage', () => {
       const fuelSelect = screen.getByRole('button', { name: /heating fuel/i });
       await selectOption(fuelSelect, 'Natural gas');
 
-      const heatPumpRadio = screen.getByRole('radio', { name: /heat pump water heater/i });
-      fireEvent.click(heatPumpRadio);
+      // Water heating fuel is required when HPWH is selected (superRefine validation)
+      const waterFuelSelect = screen.getByRole('button', { name: /water heating type/i });
+      await selectOption(waterFuelSelect, 'Natural gas');
 
-      fireEvent.click(screen.getByRole('button', { name: /calculate impact/i }));
+      const hpwhRadio = screen.getByRole('radio', { name: /heat pump water heater/i });
+      fireEvent.click(hpwhRadio);
     };
 
     it('does not show validation errors on valid submission', async () => {
-      await fillAndSubmit();
+      await fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /calculate impact/i }));
 
       await waitFor(() => {
         expect(screen.queryByText(/please select a household type/i)).not.toBeInTheDocument();
         expect(screen.queryByText(/please enter a valid street address/i)).not.toBeInTheDocument();
         expect(screen.queryByText(/please select a heating fuel/i)).not.toBeInTheDocument();
         expect(screen.queryByText(/please select an upgrade option/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/please select a water heating fuel/i)).not.toBeInTheDocument();
       });
     });
 
+    it('renders the results card after a successful API response', async () => {
+      (jest.requireMock('./fetchRemImpact').fetchRemImpact as jest.Mock).mockResolvedValue(MOCK_RESULT);
+      await fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /calculate impact/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/bill and emissions impact/i)).toBeInTheDocument();
+      });
+      expect(screen.getByRole('heading', { name: /energy bill impact/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /^emissions impact$/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /your household info/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /selected upgrade/i })).toBeInTheDocument();
+    });
+
+    it('returns to the form when the edit button is clicked', async () => {
+      (jest.requireMock('./fetchRemImpact').fetchRemImpact as jest.Mock).mockResolvedValue(MOCK_RESULT);
+      await fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /calculate impact/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/bill and emissions impact/i)).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /edit household info/i }));
+
+      expect(screen.getByRole('button', { name: /calculate impact/i })).toBeInTheDocument();
+    });
   });
 
   describe('accessibility', () => {

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.test.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.test.tsx
@@ -24,6 +24,16 @@ jest.mock('../../Icons/Coin.svg', () => ({
   ReactComponent: () => <svg data-testid="coin-icon" />,
 }));
 
+jest.mock('../../../Config/configHook', () => ({
+  useFeatureFlag: jest.fn(),
+}));
+
+// Plain function (not jest.fn) so clearAllMocks() doesn't reset it.
+// Stays in loading state permanently — these tests only verify no validation errors appear.
+jest.mock('./fetchRemImpact', () => ({
+  fetchRemImpact: () => new Promise(() => {}),
+}));
+
 const renderPage = (route = '/cesn/test-uuid/results/energy-rebates/waterHeater/calculate-impact') =>
   render(
     <IntlProvider locale="en" defaultLocale="en">
@@ -45,6 +55,9 @@ const selectOption = async (selectElement: HTMLElement, optionText: string) => {
 describe('CalculateImpactPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Re-apply after clearAllMocks resets the return value. The flag must be true
+    // for these tests — they exercise the form, not the flag-off code path.
+    (jest.requireMock('../../../Config/configHook').useFeatureFlag as jest.Mock).mockReturnValue(true);
   });
 
   describe('rendering', () => {
@@ -207,9 +220,10 @@ describe('CalculateImpactPage', () => {
 
     it('allows selecting an upgrade option via radio button', () => {
       renderPage();
-      const heatPumpRadio = screen.getByRole('radio', { name: /^heat pump$/i });
-      fireEvent.click(heatPumpRadio);
-      expect(heatPumpRadio).toBeChecked();
+      // Only "Heat pump water heater" is enabled in Step 3; other options are "Coming soon".
+      const hpwhRadio = screen.getByRole('radio', { name: /heat pump water heater/i });
+      fireEvent.click(hpwhRadio);
+      expect(hpwhRadio).toBeChecked();
     });
   });
 
@@ -226,7 +240,7 @@ describe('CalculateImpactPage', () => {
       const fuelSelect = screen.getByRole('button', { name: /heating fuel/i });
       await selectOption(fuelSelect, 'Natural gas');
 
-      const heatPumpRadio = screen.getByRole('radio', { name: /^heat pump$/i });
+      const heatPumpRadio = screen.getByRole('radio', { name: /heat pump water heater/i });
       fireEvent.click(heatPumpRadio);
 
       fireEvent.click(screen.getByRole('button', { name: /calculate impact/i }));

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.tsx
@@ -171,10 +171,6 @@ export default function CalculateImpactPage() {
     isAdminView,
   );
 
-  usePageTitle(OTHER_PAGE_TITLES.energyCalculatorCalculateImpact);
-
-  if (!showCalculateImpact) return null;
-
   const {
     control,
     handleSubmit,
@@ -189,6 +185,10 @@ export default function CalculateImpactPage() {
       upgradeChoice: undefined,
     },
   });
+
+  usePageTitle(OTHER_PAGE_TITLES.energyCalculatorCalculateImpact);
+
+  if (!showCalculateImpact) return null;
 
   const onSubmit = (data: CalculateImpactFormData) => {
     if (!whiteLabel) return;

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.tsx
@@ -202,6 +202,7 @@ export default function CalculateImpactPage() {
 
   const onSubmit = (data: CalculateImpactFormData) => {
     if (!whiteLabel) return;
+    if (submitState.status === 'loading') return;
     const payload = buildCalculateImpactPayload({
       upgradeChoice: data.upgradeChoice,
       address: data.address,
@@ -639,7 +640,7 @@ export default function CalculateImpactPage() {
             )}
           </FormControl>
 
-          <Button type="submit" variant="contained" color="primary" size="medium" className="calculate-impact-submit">
+          <Button type="submit" variant="contained" color="primary" size="medium" className="calculate-impact-submit" disabled={submitState.status === 'loading'} aria-busy={submitState.status === 'loading'}>
             <FormattedMessage id="energyCalculator.calculateImpact.submit" defaultMessage="Calculate impact" />
           </Button>
         </section>

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.tsx
@@ -29,6 +29,7 @@ import {
   type RemFuelType,
   type RemImpactApiResponse,
   type CalculateImpactFormValues,
+  isValidRemImpactApiResponse,
 } from './remCalculateImpactTypes';
 import { fetchRemImpact } from './fetchRemImpact';
 import { buildCalculateImpactPayload } from './remCalculateImpactTypes';
@@ -212,9 +213,13 @@ export default function CalculateImpactPage() {
     });
     setSubmitState({ status: 'loading' });
     fetchRemImpact(whiteLabel, payload.remAddressQuery)
-      .then((result) =>
-        setSubmitState({ status: 'success', result, formValues: data }),
-      )
+      .then((result) => {
+        if (!isValidRemImpactApiResponse(result)) {
+          setSubmitState({ status: 'error', message: 'Unexpected response from Rewiring America.' });
+          return;
+        }
+        setSubmitState({ status: 'success', result, formValues: data });
+      })
       .catch((err: Error) =>
         setSubmitState({ status: 'error', message: err.message }),
       );

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.tsx
@@ -529,7 +529,7 @@ export default function CalculateImpactPage() {
                   defaultMessage="Select your water heating fuel to see the impact of a water heater upgrade."
                 />
               </p>
-              <FormControl fullWidth>
+              <FormControl fullWidth error={!!errors.waterHeatingFuel}>
                 <Controller
                   name="waterHeatingFuel"
                   control={control}
@@ -575,6 +575,9 @@ export default function CalculateImpactPage() {
                     </Select>
                   )}
                 />
+                {errors.waterHeatingFuel && (
+                  <FormHelperText>{errors.waterHeatingFuel.message}</FormHelperText>
+                )}
               </FormControl>
             </div>
           </div>

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
@@ -18,14 +18,21 @@ import {
   Typography,
 } from '@mui/material';
 import LeftArrowIcon from '@mui/icons-material/KeyboardArrowLeft';
+import { Alert, CircularProgress } from '@mui/material';
 import { TrackedOutboundLink } from '../../../Common/TrackedOutboundLink';
 import { usePageTitle } from '../../../Common/usePageTitle';
 import { OTHER_PAGE_TITLES } from '../../../../Assets/pageTitleTags';
+import { useFeatureFlag } from '../../../Config/configHook';
 import {
   type CalculateImpactHouseholdType,
   type CalculateImpactUpgradeChoice,
   type RemFuelType,
+  type RemImpactApiResponse,
+  type CalculateImpactFormValues,
 } from './remCalculateImpactTypes';
+import { fetchRemImpact } from './fetchRemImpact';
+import { buildCalculateImpactPayload } from './remCalculateImpactTypes';
+import CalculateImpactResults from './CalculateImpactResults';
 import { ReactComponent as Coin } from '../../Icons/Coin.svg';
 import './CalculateImpactPage.css';
 
@@ -144,12 +151,20 @@ const calculateImpactSchema = z.object({
 
 type CalculateImpactFormData = z.infer<typeof calculateImpactSchema>;
 
+type SubmitState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; result: RemImpactApiResponse; formValues: CalculateImpactFormValues }
+  | { status: 'error'; message: string };
+
 export default function CalculateImpactPage() {
   const intl = useIntl();
   const navigate = useNavigate();
   const { whiteLabel, uuid } = useParams();
   const [searchParams] = useSearchParams();
   const isAdminView = useMemo(() => searchParams.get('admin') === 'true', [searchParams]);
+  const showCalculateImpact = useFeatureFlag('cesn_heat_pump_journey');
+  const [submitState, setSubmitState] = useState<SubmitState>({ status: 'idle' });
 
   const backLink = addAdminToLink(
     `/${whiteLabel}/${uuid}/results/energy-rebates/hvac`,
@@ -157,6 +172,8 @@ export default function CalculateImpactPage() {
   );
 
   usePageTitle(OTHER_PAGE_TITLES.energyCalculatorCalculateImpact);
+
+  if (!showCalculateImpact) return null;
 
   const {
     control,
@@ -173,10 +190,92 @@ export default function CalculateImpactPage() {
     },
   });
 
-  const onSubmit = (_data: CalculateImpactFormData) => {
-    // MFB-981 (Step 3) will wire this submit handler to the Rewiring America REM API.
-    // Intentionally a no-op until then — see remCalculateImpactTypes.ts for the payload shape.
+  const onSubmit = (data: CalculateImpactFormData) => {
+    if (!whiteLabel) return;
+    const payload = buildCalculateImpactPayload({
+      upgradeChoice: data.upgradeChoice,
+      address: data.address,
+      heatingFuel: data.heatingFuel,
+      waterHeatingFuel: data.waterHeatingFuel ?? '',
+      householdType: data.householdType,
+    });
+    setSubmitState({ status: 'loading' });
+    fetchRemImpact(whiteLabel, payload.remAddressQuery)
+      .then((result) =>
+        setSubmitState({ status: 'success', result, formValues: data }),
+      )
+      .catch((err: Error) =>
+        setSubmitState({ status: 'error', message: err.message }),
+      );
   };
+
+  if (submitState.status === 'success') {
+    return (
+      <main className="benefits-form calculate-impact-page">
+        <div className="calculate-impact-back-row results-back-save-btn-container">
+          <button
+            data-testid="back-to-results-button"
+            className="results-back-save-buttons"
+            onClick={() => navigate(backLink)}
+            aria-label={intl.formatMessage({ id: 'backAndSaveBtns.backBtnAL', defaultMessage: 'back' })}
+          >
+            <div className="btn-icon-text-container padding-right">
+              <LeftArrowIcon />
+              <FormattedMessage
+                id="energyCalculator.calculateImpact.backToResults"
+                defaultMessage="BACK TO RESULTS"
+              />
+            </div>
+          </button>
+        </div>
+
+        <header className="calculate-impact-header">
+          <Coin aria-hidden="true" className="calculate-impact-icon" />
+          <div className="calculate-impact-header-text">
+            <span className="calculate-impact-title-text">
+              <FormattedMessage
+                id="energyCalculator.calculateImpact.titleLabel"
+                defaultMessage="Bill Impact Calculator"
+              />
+            </span>
+            <hr className="calculate-impact-separator" />
+            <h1 className="calculate-impact-subtitle">
+              <FormattedMessage
+                id="energyCalculator.calculateImpact.subtitle"
+                defaultMessage="Estimated Savings"
+              />
+            </h1>
+          </div>
+        </header>
+
+        <Typography variant="body1" className="calculate-impact-intro energy-calculator-body-text">
+          <FormattedMessage
+            id="energyCalculator.calculateImpact.intro"
+            defaultMessage="This data modeling is by {rewiringAmerica}, an independent nonprofit that supports customers accessing electrification rebates and home energy upgrades provides a range of the impact of your selected upgrade on your energy bill, and emissions reductions estimates for your project."
+            values={{
+              rewiringAmerica: (
+                <TrackedOutboundLink
+                  href="https://www.rewiringamerica.org"
+                  className="link-color"
+                  action="calculate_impact_rewiring_america"
+                  label="Rewiring America"
+                  category="energy_rebate"
+                >
+                  <FormattedMessage id="co.energy.rewiring_america_link" defaultMessage="Rewiring America" />
+                </TrackedOutboundLink>
+              ),
+            }}
+          />
+        </Typography>
+
+        <CalculateImpactResults
+          result={submitState.result}
+          formValues={submitState.formValues}
+          onEdit={() => setSubmitState({ status: 'idle' })}
+        />
+      </main>
+    );
+  }
 
   return (
     <main className="benefits-form calculate-impact-page">
@@ -235,6 +334,20 @@ export default function CalculateImpactPage() {
           }}
         />
       </Typography>
+
+      {submitState.status === 'loading' && (
+        <div className="calculate-impact-loading">
+          <CircularProgress size={28} aria-label={intl.formatMessage({ id: 'general.loading', defaultMessage: 'Loading' })} />
+        </div>
+      )}
+      {submitState.status === 'error' && (
+        <Alert severity="error" className="calculate-impact-error">
+          <FormattedMessage
+            id="energyCalculator.calculateImpact.error"
+            defaultMessage="Something went wrong calculating your impact. Please try again."
+          />
+        </Alert>
+      )}
 
       <Box component="form" onSubmit={handleSubmit(onSubmit)} noValidate>
         <section className="calculate-impact-card" aria-labelledby="calculate-impact-household-heading">
@@ -476,18 +589,29 @@ export default function CalculateImpactPage() {
                 >
                   {UPGRADE_OPTIONS.map((opt) => {
                     const isSelected = field.value === opt.value;
+                    const isAvailable = opt.value === 'heat_pump_water_heater';
                     return (
                       <div
                         key={opt.value}
                         className="calculate-impact-radio-option"
                         data-selected={isSelected ? 'true' : 'false'}
+                        data-disabled={!isAvailable ? 'true' : 'false'}
                       >
                         <FormControlLabel
                           value={opt.value}
+                          disabled={!isAvailable}
                           control={<Radio />}
                           label={
                             <span className="calculate-impact-radio-label">
                               <FormattedMessage id={opt.messageId} defaultMessage={opt.defaultMessage} />
+                              {!isAvailable && (
+                                <span className="calculate-impact-coming-soon">
+                                  <FormattedMessage
+                                    id="energyCalculator.calculateImpact.comingSoon"
+                                    defaultMessage="Coming soon"
+                                  />
+                                </span>
+                              )}
                             </span>
                           }
                         />

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.tsx
@@ -131,23 +131,33 @@ const UPGRADE_CHOICE_VALUES: [CalculateImpactUpgradeChoice, ...CalculateImpactUp
   'heat_pump_water_heater',
 ];
 
-const calculateImpactSchema = z.object({
-  householdType: z.enum(HOUSEHOLD_TYPE_VALUES, {
-    required_error: 'Please select a household type.',
-  }),
-  address: z
-    .string()
-    .min(1, 'Please enter a valid street address.')
-    .transform((val) => val.trim())
-    .refine((val) => val.length > 0, { message: 'Please enter a valid street address.' }),
-  heatingFuel: z.enum(FUEL_TYPE_VALUES, {
-    required_error: 'Please select a heating fuel.',
-  }),
-  waterHeatingFuel: z.enum(FUEL_TYPE_VALUES).optional(),
-  upgradeChoice: z.enum(UPGRADE_CHOICE_VALUES, {
-    required_error: 'Please select an upgrade option.',
-  }),
-});
+const calculateImpactSchema = z
+  .object({
+    householdType: z.enum(HOUSEHOLD_TYPE_VALUES, {
+      required_error: 'Please select a household type.',
+    }),
+    address: z
+      .string()
+      .min(1, 'Please enter a valid street address.')
+      .transform((val) => val.trim())
+      .refine((val) => val.length > 0, { message: 'Please enter a valid street address.' }),
+    heatingFuel: z.enum(FUEL_TYPE_VALUES, {
+      required_error: 'Please select a heating fuel.',
+    }),
+    waterHeatingFuel: z.enum(FUEL_TYPE_VALUES).optional(),
+    upgradeChoice: z.enum(UPGRADE_CHOICE_VALUES, {
+      required_error: 'Please select an upgrade option.',
+    }),
+  })
+  .superRefine((data, ctx) => {
+    if (data.upgradeChoice === 'heat_pump_water_heater' && !data.waterHeatingFuel) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['waterHeatingFuel'],
+        message: 'Please select a water heating fuel for this upgrade.',
+      });
+    }
+  });
 
 type CalculateImpactFormData = z.infer<typeof calculateImpactSchema>;
 

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactResults.test.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactResults.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import CalculateImpactResults from './CalculateImpactResults';
+import type { RemImpactApiResponse, CalculateImpactFormValues } from './remCalculateImpactTypes';
+
+// ─── Shared test data ──────────────────────────────────────────────────────────
+
+const FORM_VALUES: CalculateImpactFormValues = {
+  householdType: 'single_family_detached',
+  address: '200 E Colfax Ave Denver, CO 80203',
+  heatingFuel: 'electricity',
+  waterHeatingFuel: 'natural_gas',
+  upgradeChoice: 'heat_pump_water_heater',
+};
+
+/** All deltas negative — range is entirely in the "savings/reduction" zone. */
+const ALL_NEGATIVE_RESULT: RemImpactApiResponse = {
+  bill_delta: {
+    mean: { value: -200, unit: '$' },
+    median: { value: -200, unit: '$' },
+    percentile_20: { value: -300, unit: '$' },
+    percentile_80: { value: -100, unit: '$' },
+  },
+  emissions_delta: {
+    mean: { value: -200, unit: 'lbCO2e' },
+    median: { value: -200, unit: 'lbCO2e' },
+    percentile_20: { value: -300, unit: 'lbCO2e' },
+    percentile_80: { value: -100, unit: 'lbCO2e' },
+  },
+};
+
+/**
+ * Bill delta crosses zero (p80 > 0, p20 < 0) — bar should split into a red
+ * (increase) section on the left and a green (savings) section on the right.
+ * Emissions remain all-negative.
+ */
+const BILL_CROSSES_ZERO_RESULT: RemImpactApiResponse = {
+  bill_delta: {
+    mean: { value: -19.76, unit: '$' },
+    median: { value: -21.91, unit: '$' },
+    percentile_20: { value: -60.52, unit: '$' },
+    percentile_80: { value: 20.50, unit: '$' },
+  },
+  emissions_delta: {
+    mean: { value: -1758.0, unit: 'lbCO2e' },
+    median: { value: -1611.7, unit: 'lbCO2e' },
+    percentile_20: { value: -2558.6, unit: 'lbCO2e' },
+    percentile_80: { value: -950.0, unit: 'lbCO2e' },
+  },
+};
+
+/**
+ * Symmetric result: median is exactly halfway between p80 and p20 for both
+ * delta types.  pctFromLeft should evaluate to exactly 50 for each median float.
+ *   leftVal = p80 = -100,  rightVal = p20 = -300,  totalRange = 200
+ *   pctFromLeft(-200) = ((-100) - (-200)) / 200 * 100 = 50
+ */
+const SYMMETRIC_RESULT: RemImpactApiResponse = {
+  bill_delta: {
+    mean: { value: -200, unit: '$' },
+    median: { value: -200, unit: '$' },
+    percentile_20: { value: -300, unit: '$' },
+    percentile_80: { value: -100, unit: '$' },
+  },
+  emissions_delta: {
+    mean: { value: -200, unit: 'lbCO2e' },
+    median: { value: -200, unit: 'lbCO2e' },
+    percentile_20: { value: -300, unit: 'lbCO2e' },
+    percentile_80: { value: -100, unit: 'lbCO2e' },
+  },
+};
+
+// ─── Helper ────────────────────────────────────────────────────────────────────
+
+const renderResults = (
+  result: RemImpactApiResponse,
+  { onEdit = jest.fn(), formValues = FORM_VALUES } = {},
+) =>
+  render(
+    <IntlProvider locale="en" defaultLocale="en">
+      <CalculateImpactResults result={result} formValues={formValues} onEdit={onEdit} />
+    </IntlProvider>,
+  );
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('CalculateImpactResults', () => {
+  describe('household info summary', () => {
+    it('renders submitted address, household type, and fuels', () => {
+      renderResults(ALL_NEGATIVE_RESULT);
+      expect(screen.getByText('200 E Colfax Ave Denver, CO 80203')).toBeInTheDocument();
+      expect(screen.getByText('House')).toBeInTheDocument();
+      expect(screen.getByText('Electricity')).toBeInTheDocument();
+      expect(screen.getByText('Natural gas')).toBeInTheDocument();
+    });
+
+    it('omits water heating row when waterHeatingFuel is not provided', () => {
+      const withoutWaterFuel: CalculateImpactFormValues = { ...FORM_VALUES, waterHeatingFuel: undefined };
+      renderResults(ALL_NEGATIVE_RESULT, { formValues: withoutWaterFuel });
+      expect(screen.queryByText(/water heating type/i)).not.toBeInTheDocument();
+    });
+
+    it('calls onEdit when the edit button is clicked', () => {
+      const onEdit = jest.fn();
+      renderResults(ALL_NEGATIVE_RESULT, { onEdit });
+      fireEvent.click(screen.getByRole('button', { name: /edit household info/i }));
+      expect(onEdit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('ImpactRangeBar — fill coloring', () => {
+    it('renders only savings fills when all values are negative', () => {
+      const { container } = renderResults(ALL_NEGATIVE_RESULT);
+      expect(container.querySelectorAll('.impact-range-bar__fill--savings').length).toBeGreaterThan(0);
+      expect(container.querySelector('.impact-range-bar__fill--increase')).toBeNull();
+    });
+
+    it('renders both a savings fill and an increase fill when bill range crosses zero', () => {
+      const { container } = renderResults(BILL_CROSSES_ZERO_RESULT);
+      expect(container.querySelector('.impact-range-bar__fill--savings')).toBeInTheDocument();
+      expect(container.querySelector('.impact-range-bar__fill--increase')).toBeInTheDocument();
+    });
+  });
+
+  describe('ImpactRangeBar — arrow signs (isSavings / directionIndicator)', () => {
+    it('renders ▼ for every end label when all values are negative', () => {
+      const { container } = renderResults(ALL_NEGATIVE_RESULT);
+      container.querySelectorAll('.impact-range-bar__arrow').forEach((arrow) => {
+        expect(arrow.textContent).toBe('▼');
+      });
+    });
+
+    it('renders ▲ for the positive (cost-increase) end label when bill range crosses zero', () => {
+      const { container } = renderResults(BILL_CROSSES_ZERO_RESULT);
+      const increaseArrows = container.querySelectorAll('.impact-range-bar__arrow--increase');
+      expect(increaseArrows.length).toBeGreaterThan(0);
+      increaseArrows.forEach((arrow) => expect(arrow.textContent).toBe('▲'));
+    });
+  });
+
+  describe('ImpactRangeBar — pctFromLeft math', () => {
+    it('positions each median float at left: 50% when the median is exactly midway between p80 and p20', () => {
+      // SYMMETRIC_RESULT: p80=-100, p20=-300, median=-200
+      // pctFromLeft(-200) = ((-100)-(-200))/((-100)-(-300)) * 100 = 100/200*100 = 50
+      const { container } = renderResults(SYMMETRIC_RESULT);
+      const floats = container.querySelectorAll('.impact-range-bar__median-float');
+      expect(floats.length).toBeGreaterThan(0);
+      floats.forEach((el) => {
+        expect(el).toHaveStyle('left: 50%');
+      });
+    });
+
+    it('clamps pctFromLeft to [0, 100] — median outside range does not overflow', () => {
+      const clampResult: RemImpactApiResponse = {
+        ...ALL_NEGATIVE_RESULT,
+        bill_delta: {
+          mean: { value: -500, unit: '$' },
+          // median is beyond p20 — pctFromLeft should clamp to 100
+          median: { value: -400, unit: '$' },
+          percentile_20: { value: -300, unit: '$' },
+          percentile_80: { value: -100, unit: '$' },
+        },
+      };
+      // Should render without errors; bar still displays
+      const { container } = renderResults(clampResult);
+      expect(container.querySelector('.impact-range-bar__median-float')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactResults.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactResults.tsx
@@ -271,11 +271,19 @@ export default function CalculateImpactResults({
             />
           </h3>
           <p className="calculate-impact-impact-description">
-            <FormattedMessage
-              id="energyCalculator.calculateImpact.results.billImpact.description"
-              defaultMessage="Our modeling shows that homes like yours will tend to save between {low} and {high} a year on their energy bills, with most homes saving at least {mostLikely}."
-              values={{ low: billRangeLow, high: billRangeHigh, mostLikely: billMostLikely }}
-            />
+            {billMedian <= 0 ? (
+              <FormattedMessage
+                id="energyCalculator.calculateImpact.results.billImpact.description.save"
+                defaultMessage="Our modeling shows that homes like yours will tend to save between {low} and {high} a year on their energy bills, with most homes saving at least {mostLikely}."
+                values={{ low: billRangeLow, high: billRangeHigh, mostLikely: billMostLikely }}
+              />
+            ) : (
+              <FormattedMessage
+                id="energyCalculator.calculateImpact.results.billImpact.description.increase"
+                defaultMessage="Our modeling shows that homes like yours will tend to see energy bills increase between {low} and {high} a year, with most homes seeing increases of at least {mostLikely}."
+                values={{ low: billRangeLow, high: billRangeHigh, mostLikely: billMostLikely }}
+              />
+            )}
           </p>
           <ImpactRangeBar
             p20={billP20}
@@ -295,11 +303,19 @@ export default function CalculateImpactResults({
             />
           </h3>
           <p className="calculate-impact-impact-description">
-            <FormattedMessage
-              id="energyCalculator.calculateImpact.results.emissionsImpact.description"
-              defaultMessage="Our modeling shows that homes like yours will tend to have annual emissions reductions between {low} and {high} lb CO₂e, with most homes reducing emissions by at least {mostLikely} lb."
-              values={{ low: emRangeLow, high: emRangeHigh, mostLikely: emMostLikely }}
-            />
+            {emMedian <= 0 ? (
+              <FormattedMessage
+                id="energyCalculator.calculateImpact.results.emissionsImpact.description.reduction"
+                defaultMessage="Our modeling shows that homes like yours will tend to have annual emissions reductions between {low} and {high} lb CO₂e, with most homes reducing emissions by at least {mostLikely} lb."
+                values={{ low: emRangeLow, high: emRangeHigh, mostLikely: emMostLikely }}
+              />
+            ) : (
+              <FormattedMessage
+                id="energyCalculator.calculateImpact.results.emissionsImpact.description.increase"
+                defaultMessage="Our modeling shows that homes like yours will tend to see annual emissions increases between {low} and {high} lb CO₂e, with most homes seeing increases of at least {mostLikely} lb."
+                values={{ low: emRangeLow, high: emRangeHigh, mostLikely: emMostLikely }}
+              />
+            )}
           </p>
           <ImpactRangeBar
             p20={emP20}

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactResults.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactResults.tsx
@@ -1,0 +1,353 @@
+import { FormattedMessage, useIntl } from 'react-intl';
+import { Chip, IconButton } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import ForestIcon from '@mui/icons-material/Forest';
+import { formatToUSD } from '../../../../utils/formatCurrency';
+import {
+  getEpaEquivalencies,
+  EPA_DATA_SOURCE_MESSAGE_ID,
+  EPA_DATA_SOURCE_DEFAULT_MESSAGE,
+} from '../../../../utils/epaEquivalencies';
+import type { RemImpactApiResponse, CalculateImpactFormValues } from './remCalculateImpactTypes';
+import {
+  HOUSEHOLD_TYPE_LABEL_MAP,
+  FUEL_TYPE_LABEL_MAP,
+  UPGRADE_LABEL_MAP,
+} from './remCalculateImpactTypes';
+
+// ─── Range bar ────────────────────────────────────────────────────────────────
+
+interface ImpactRangeBarProps {
+  p20: number;   // percentile_20 — most favorable (right end)
+  median: number;
+  p80: number;   // percentile_80 — least favorable (left end)
+  formatValue: (absValue: number) => string;
+  unitSuffix: string;
+}
+
+function directionIndicator(value: number): string {
+  return value <= 0 ? '▼' : '▲';
+}
+
+function formatEndLabel(value: number, formatFn: (n: number) => string): string {
+  return `${directionIndicator(value)}${formatFn(Math.abs(value))}`;
+}
+
+function ImpactRangeBar({ p20, median, p80, formatValue, unitSuffix }: ImpactRangeBarProps) {
+  // Left = p80 (least favorable), right = p20 (most favorable)
+  const leftVal = p80;
+  const rightVal = p20;
+  const totalRange = leftVal - rightVal;
+
+  if (totalRange === 0) return null;
+
+  // Percent from left edge for a given value
+  const pctFromLeft = (v: number): number =>
+    Math.max(0, Math.min(100, ((leftVal - v) / totalRange) * 100));
+
+  const medianPct = pctFromLeft(median);
+  const crossesZero = leftVal > 0 && rightVal < 0;
+  const zeroPct = crossesZero ? pctFromLeft(0) : null;
+  const allNegative = leftVal <= 0;
+
+  const medianLabel = `${directionIndicator(median)}${formatValue(Math.abs(median))}${unitSuffix}`;
+
+  return (
+    <div className="impact-range-bar">
+      {/* Median label + downward caret, centered above the median position */}
+      <div className="impact-range-bar__median-wrapper">
+        <div
+          className="impact-range-bar__median-float"
+          style={{ left: `${medianPct}%` }}
+          aria-hidden="true"
+        >
+          <span className="impact-range-bar__median-value">{medianLabel}</span>
+          <span className="impact-range-bar__median-caret">▼</span>
+        </div>
+      </div>
+
+      {/* Colored bar track */}
+      <div className="impact-range-bar__track" role="presentation">
+        {crossesZero && zeroPct !== null ? (
+          <>
+            <div
+              className="impact-range-bar__fill impact-range-bar__fill--increase"
+              style={{ left: 0, width: `${zeroPct}%` }}
+            />
+            <div
+              className="impact-range-bar__fill impact-range-bar__fill--savings"
+              style={{ left: `${zeroPct}%`, width: `${100 - zeroPct}%` }}
+            />
+          </>
+        ) : (
+          <div
+            className={`impact-range-bar__fill ${allNegative ? 'impact-range-bar__fill--savings' : 'impact-range-bar__fill--increase'}`}
+            style={{ left: 0, width: '100%' }}
+          />
+        )}
+      </div>
+
+      {/* End labels */}
+      <div className="impact-range-bar__end-labels">
+        <span className={leftVal > 0 ? 'impact-range-bar__label--increase' : 'impact-range-bar__label--savings'}>
+          {formatEndLabel(leftVal, formatValue)}
+        </span>
+        <span className={rightVal > 0 ? 'impact-range-bar__label--increase' : 'impact-range-bar__label--savings'}>
+          {formatEndLabel(rightVal, formatValue)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main results component ───────────────────────────────────────────────────
+
+interface CalculateImpactResultsProps {
+  result: RemImpactApiResponse;
+  formValues: CalculateImpactFormValues;
+  onEdit: () => void;
+}
+
+function formatEmissionsLbs(n: number): string {
+  return `${Math.round(n).toLocaleString()}lb`;
+}
+
+export default function CalculateImpactResults({
+  result,
+  formValues,
+  onEdit,
+}: CalculateImpactResultsProps) {
+  const intl = useIntl();
+
+  const householdLabel = HOUSEHOLD_TYPE_LABEL_MAP[formValues.householdType];
+  const heatingFuelLabel = FUEL_TYPE_LABEL_MAP[formValues.heatingFuel];
+  const waterHeatingFuelLabel = formValues.waterHeatingFuel
+    ? FUEL_TYPE_LABEL_MAP[formValues.waterHeatingFuel]
+    : null;
+  const upgradeLabel = UPGRADE_LABEL_MAP[formValues.upgradeChoice];
+
+  // Bill range values (absolute)
+  const billP20 = result.bill_delta.percentile_20.value;
+  const billMedian = result.bill_delta.median.value;
+  const billP80 = result.bill_delta.percentile_80.value;
+  const billRangeLow = formatToUSD(Math.min(Math.abs(billP20), Math.abs(billP80)));
+  const billRangeHigh = formatToUSD(Math.max(Math.abs(billP20), Math.abs(billP80)));
+  const billMostLikely = formatToUSD(Math.abs(billMedian));
+
+  // Emissions range values (absolute)
+  const emP20 = result.emissions_delta.percentile_20.value;
+  const emMedian = result.emissions_delta.median.value;
+  const emP80 = result.emissions_delta.percentile_80.value;
+  const emRangeLow = Math.round(Math.min(Math.abs(emP20), Math.abs(emP80))).toLocaleString();
+  const emRangeHigh = Math.round(Math.max(Math.abs(emP20), Math.abs(emP80))).toLocaleString();
+  const emMostLikely = Math.round(Math.abs(emMedian)).toLocaleString();
+
+  const equivalencies = getEpaEquivalencies(emMedian);
+
+  return (
+    <div className="calculate-impact-results">
+      {/* ── Household info summary card ── */}
+      <section
+        className="calculate-impact-card calculate-impact-summary-card"
+        aria-labelledby="ci-summary-heading"
+      >
+        <div className="calculate-impact-summary-header">
+          <h2 id="ci-summary-heading" className="calculate-impact-section-title">
+            <FormattedMessage
+              id="energyCalculator.calculateImpact.section.household"
+              defaultMessage="Your household info"
+            />
+          </h2>
+          <IconButton
+            size="small"
+            onClick={onEdit}
+            aria-label={intl.formatMessage({
+              id: 'energyCalculator.calculateImpact.summary.editAL',
+              defaultMessage: 'Edit household info',
+            })}
+            className="calculate-impact-edit-btn"
+          >
+            <EditIcon fontSize="small" />
+          </IconButton>
+        </div>
+
+        <dl className="calculate-impact-summary-fields">
+          <div className="calculate-impact-summary-field">
+            <dt>
+              <FormattedMessage
+                id="energyCalculator.calculateImpact.field.householdType"
+                defaultMessage="Household Type"
+              />
+            </dt>
+            <dd>
+              <FormattedMessage
+                id={householdLabel.messageId}
+                defaultMessage={householdLabel.defaultMessage}
+              />
+            </dd>
+          </div>
+          <div className="calculate-impact-summary-field">
+            <dt>
+              <FormattedMessage
+                id="energyCalculator.calculateImpact.field.address"
+                defaultMessage="Address"
+              />
+            </dt>
+            <dd>{formValues.address}</dd>
+          </div>
+          <div className="calculate-impact-summary-field">
+            <dt>
+              <FormattedMessage
+                id="energyCalculator.calculateImpact.field.heatingFuel"
+                defaultMessage="Heating Fuel"
+              />
+            </dt>
+            <dd>
+              <FormattedMessage
+                id={heatingFuelLabel.messageId}
+                defaultMessage={heatingFuelLabel.defaultMessage}
+              />
+            </dd>
+          </div>
+          {waterHeatingFuelLabel && (
+            <div className="calculate-impact-summary-field">
+              <dt>
+                <FormattedMessage
+                  id="energyCalculator.calculateImpact.field.waterHeatingFuelShort"
+                  defaultMessage="Water Heating Type"
+                />
+              </dt>
+              <dd>
+                <FormattedMessage
+                  id={waterHeatingFuelLabel.messageId}
+                  defaultMessage={waterHeatingFuelLabel.defaultMessage}
+                />
+              </dd>
+            </div>
+          )}
+        </dl>
+      </section>
+
+      {/* ── Selected upgrade ── */}
+      <section className="calculate-impact-selected-upgrade" aria-labelledby="ci-upgrade-heading">
+        <h2 id="ci-upgrade-heading" className="calculate-impact-section-title">
+          <FormattedMessage
+            id="energyCalculator.calculateImpact.section.upgrade"
+            defaultMessage="Selected upgrade"
+          />
+        </h2>
+        <div className="calculate-impact-upgrade-value">
+          <FormattedMessage
+            id={upgradeLabel.messageId}
+            defaultMessage={upgradeLabel.defaultMessage}
+          />
+        </div>
+      </section>
+
+      {/* ── Bill and emissions impact card ── */}
+      <section
+        className="calculate-impact-card calculate-impact-results-card"
+        aria-labelledby="ci-impact-heading"
+      >
+        <h2 id="ci-impact-heading" className="calculate-impact-section-title">
+          <FormattedMessage
+            id="energyCalculator.calculateImpact.results.title"
+            defaultMessage="Bill and emissions impact"
+          />
+        </h2>
+        <p className="calculate-impact-section-description">
+          <FormattedMessage
+            id="energyCalculator.calculateImpact.results.description"
+            defaultMessage="We calculated the impact estimates below based on your selected upgrade, the household info you shared, and other characteristics we found for this home."
+          />
+        </p>
+
+        {/* Energy bill impact */}
+        <div className="calculate-impact-impact-section">
+          <h3 className="calculate-impact-impact-title">
+            <FormattedMessage
+              id="energyCalculator.calculateImpact.results.billImpact.title"
+              defaultMessage="Energy bill impact"
+            />
+          </h3>
+          <p className="calculate-impact-impact-description">
+            <FormattedMessage
+              id="energyCalculator.calculateImpact.results.billImpact.description"
+              defaultMessage="Our modeling shows that homes like yours will tend to save between {low} and {high} a year on their energy bills, with most homes saving at least {mostLikely}."
+              values={{ low: billRangeLow, high: billRangeHigh, mostLikely: billMostLikely }}
+            />
+          </p>
+          <ImpactRangeBar
+            p20={billP20}
+            median={billMedian}
+            p80={billP80}
+            formatValue={(n) => formatToUSD(n)}
+            unitSuffix="/yr"
+          />
+        </div>
+
+        {/* Emissions impact */}
+        <div className="calculate-impact-impact-section">
+          <h3 className="calculate-impact-impact-title">
+            <FormattedMessage
+              id="energyCalculator.calculateImpact.results.emissionsImpact.title"
+              defaultMessage="Emissions impact"
+            />
+          </h3>
+          <p className="calculate-impact-impact-description">
+            <FormattedMessage
+              id="energyCalculator.calculateImpact.results.emissionsImpact.description"
+              defaultMessage="Our modeling shows that homes like yours will tend to have annual emissions reductions between {low} and {high} lb CO₂e, with most homes reducing emissions by at least {mostLikely} lb."
+              values={{ low: emRangeLow, high: emRangeHigh, mostLikely: emMostLikely }}
+            />
+          </p>
+          <ImpactRangeBar
+            p20={emP20}
+            median={emMedian}
+            p80={emP80}
+            formatValue={(n) => formatEmissionsLbs(n)}
+            unitSuffix=" CO₂e/yr"
+          />
+
+          {/* EPA equivalencies */}
+          <div className="calculate-impact-epa-section">
+            <p className="calculate-impact-epa-intro">
+              <FormattedMessage
+                id="energyCalculator.calculateImpact.epa.intro"
+                defaultMessage="This is equivalent to carbon sequestered by:"
+              />
+            </p>
+            <div className="calculate-impact-epa-chips">
+              {equivalencies.map((eq) => (
+                <Chip
+                  key={eq.id}
+                  icon={<ForestIcon />}
+                  label={
+                    <FormattedMessage
+                      id={eq.labelMessageId}
+                      defaultMessage={eq.labelDefaultMessage}
+                      values={{ value: eq.value.toFixed(1) }}
+                    />
+                  }
+                  className="calculate-impact-epa-chip"
+                />
+              ))}
+            </div>
+            <p className="calculate-impact-epa-source">
+              <FormattedMessage
+                id="energyCalculator.calculateImpact.epa.dataSourceLabel"
+                defaultMessage="Data source: {source}"
+                values={{
+                  source: intl.formatMessage({
+                    id: EPA_DATA_SOURCE_MESSAGE_ID,
+                    defaultMessage: EPA_DATA_SOURCE_DEFAULT_MESSAGE,
+                  }),
+                }}
+              />
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactResults.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactResults.tsx
@@ -1,5 +1,5 @@
 import { FormattedMessage, useIntl } from 'react-intl';
-import { Chip, IconButton } from '@mui/material';
+import { IconButton } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import ForestIcon from '@mui/icons-material/Forest';
 import { formatToUSD } from '../../../../utils/formatCurrency';
@@ -25,12 +25,33 @@ interface ImpactRangeBarProps {
   unitSuffix: string;
 }
 
-function directionIndicator(value: number): string {
-  return value <= 0 ? '▼' : '▲';
+function isSavings(value: number): boolean {
+  return value <= 0;
 }
 
-function formatEndLabel(value: number, formatFn: (n: number) => string): string {
-  return `${directionIndicator(value)}${formatFn(Math.abs(value))}`;
+/** Arrow (▼/▲) is colored; number is black. */
+function ArrowNumber({
+  value,
+  formatFn,
+  suffix = '',
+}: {
+  value: number;
+  formatFn: (n: number) => string;
+  suffix?: string;
+}) {
+  const arrow = isSavings(value) ? '▼' : '▲';
+  const colorClass = isSavings(value)
+    ? 'impact-range-bar__arrow--savings'
+    : 'impact-range-bar__arrow--increase';
+  return (
+    <>
+      <span className={`impact-range-bar__arrow ${colorClass}`}>{arrow}</span>
+      <span className="impact-range-bar__number">
+        {formatFn(Math.abs(value))}
+        {suffix}
+      </span>
+    </>
+  );
 }
 
 function ImpactRangeBar({ p20, median, p80, formatValue, unitSuffix }: ImpactRangeBarProps) {
@@ -50,18 +71,18 @@ function ImpactRangeBar({ p20, median, p80, formatValue, unitSuffix }: ImpactRan
   const zeroPct = crossesZero ? pctFromLeft(0) : null;
   const allNegative = leftVal <= 0;
 
-  const medianLabel = `${directionIndicator(median)}${formatValue(Math.abs(median))}${unitSuffix}`;
-
   return (
     <div className="impact-range-bar">
-      {/* Median label + downward caret, centered above the median position */}
+      {/* Median label + caret, floats above the bar */}
       <div className="impact-range-bar__median-wrapper">
         <div
           className="impact-range-bar__median-float"
           style={{ left: `${medianPct}%` }}
           aria-hidden="true"
         >
-          <span className="impact-range-bar__median-value">{medianLabel}</span>
+          <span className="impact-range-bar__median-value">
+            <ArrowNumber value={median} formatFn={formatValue} suffix={unitSuffix} />
+          </span>
           <span className="impact-range-bar__median-caret">▼</span>
         </div>
       </div>
@@ -85,15 +106,37 @@ function ImpactRangeBar({ p20, median, p80, formatValue, unitSuffix }: ImpactRan
             style={{ left: 0, width: '100%' }}
           />
         )}
+        {/* Circle indicator at median position */}
+        <div
+          className="impact-range-bar__median-circle"
+          style={{ left: `${medianPct}%` }}
+        />
+        {/* Grey oval marker at zero crossing — text label is in the end-labels row below */}
+        {crossesZero && zeroPct !== null && (
+          <div
+            className="impact-range-bar__zero-pill"
+            style={{ left: `${zeroPct}%` }}
+            aria-hidden="true"
+          />
+        )}
       </div>
 
-      {/* End labels */}
+      {/* End labels — left/right percentiles + $0 reference at zero crossing */}
       <div className="impact-range-bar__end-labels">
-        <span className={leftVal > 0 ? 'impact-range-bar__label--increase' : 'impact-range-bar__label--savings'}>
-          {formatEndLabel(leftVal, formatValue)}
+        <span className="impact-range-bar__end-label">
+          <ArrowNumber value={leftVal} formatFn={formatValue} />
         </span>
-        <span className={rightVal > 0 ? 'impact-range-bar__label--increase' : 'impact-range-bar__label--savings'}>
-          {formatEndLabel(rightVal, formatValue)}
+        {crossesZero && zeroPct !== null && (
+          <span
+            className="impact-range-bar__zero-label"
+            style={{ left: `${zeroPct}%` }}
+            aria-hidden="true"
+          >
+            {formatValue(0)}
+          </span>
+        )}
+        <span className="impact-range-bar__end-label">
+          <ArrowNumber value={rightVal} formatFn={formatValue} />
         </span>
       </div>
     </div>
@@ -145,10 +188,10 @@ export default function CalculateImpactResults({
   const equivalencies = getEpaEquivalencies(emMedian);
 
   return (
-    <div className="calculate-impact-results">
+    <div className="calculate-impact-results-outer-card">
       {/* ── Household info summary card ── */}
       <section
-        className="calculate-impact-card calculate-impact-summary-card"
+        className="calculate-impact-summary-card"
         aria-labelledby="ci-summary-heading"
       >
         <div className="calculate-impact-summary-header">
@@ -232,7 +275,7 @@ export default function CalculateImpactResults({
       <section className="calculate-impact-selected-upgrade" aria-labelledby="ci-upgrade-heading">
         <h2 id="ci-upgrade-heading" className="calculate-impact-section-title">
           <FormattedMessage
-            id="energyCalculator.calculateImpact.section.upgrade"
+            id="energyCalculator.calculateImpact.results.selectedUpgrade"
             defaultMessage="Selected upgrade"
           />
         </h2>
@@ -244,9 +287,9 @@ export default function CalculateImpactResults({
         </div>
       </section>
 
-      {/* ── Bill and emissions impact card ── */}
+      {/* ── Bill and emissions impact ── */}
       <section
-        className="calculate-impact-card calculate-impact-results-card"
+        className="calculate-impact-bill-emissions-section"
         aria-labelledby="ci-impact-heading"
       >
         <h2 id="ci-impact-heading" className="calculate-impact-section-title">
@@ -262,105 +305,109 @@ export default function CalculateImpactResults({
           />
         </p>
 
-        {/* Energy bill impact */}
-        <div className="calculate-impact-impact-section">
-          <h3 className="calculate-impact-impact-title">
-            <FormattedMessage
-              id="energyCalculator.calculateImpact.results.billImpact.title"
-              defaultMessage="Energy bill impact"
-            />
-          </h3>
-          <p className="calculate-impact-impact-description">
-            {billMedian <= 0 ? (
+        {/* Indented subsections */}
+        <div className="calculate-impact-impact-indented">
+          {/* Energy bill impact */}
+          <div className="calculate-impact-impact-section">
+            <h3 className="calculate-impact-impact-title">
               <FormattedMessage
-                id="energyCalculator.calculateImpact.results.billImpact.description.save"
-                defaultMessage="Our modeling shows that homes like yours will tend to save between {low} and {high} a year on their energy bills, with most homes saving at least {mostLikely}."
-                values={{ low: billRangeLow, high: billRangeHigh, mostLikely: billMostLikely }}
+                id="energyCalculator.calculateImpact.results.billImpact.title"
+                defaultMessage="Energy bill impact"
               />
-            ) : (
+            </h3>
+            <p className="calculate-impact-impact-description">
+              {billMedian <= 0 ? (
+                <FormattedMessage
+                  id="energyCalculator.calculateImpact.results.billImpact.description.save"
+                  defaultMessage="Our modeling shows that homes like yours will tend to save between {low} and {high} a year on their energy bills, with most homes saving at least {mostLikely}."
+                  values={{ low: billRangeLow, high: billRangeHigh, mostLikely: billMostLikely }}
+                />
+              ) : (
+                <FormattedMessage
+                  id="energyCalculator.calculateImpact.results.billImpact.description.increase"
+                  defaultMessage="Our modeling shows that homes like yours will tend to see energy bills increase between {low} and {high} a year, with most homes seeing increases of at least {mostLikely}."
+                  values={{ low: billRangeLow, high: billRangeHigh, mostLikely: billMostLikely }}
+                />
+              )}
+              {' '}
               <FormattedMessage
-                id="energyCalculator.calculateImpact.results.billImpact.description.increase"
-                defaultMessage="Our modeling shows that homes like yours will tend to see energy bills increase between {low} and {high} a year, with most homes seeing increases of at least {mostLikely}."
-                values={{ low: billRangeLow, high: billRangeHigh, mostLikely: billMostLikely }}
-              />
-            )}
-          </p>
-          <ImpactRangeBar
-            p20={billP20}
-            median={billMedian}
-            p80={billP80}
-            formatValue={(n) => formatToUSD(n)}
-            unitSuffix="/yr"
-          />
-        </div>
-
-        {/* Emissions impact */}
-        <div className="calculate-impact-impact-section">
-          <h3 className="calculate-impact-impact-title">
-            <FormattedMessage
-              id="energyCalculator.calculateImpact.results.emissionsImpact.title"
-              defaultMessage="Emissions impact"
-            />
-          </h3>
-          <p className="calculate-impact-impact-description">
-            {emMedian <= 0 ? (
-              <FormattedMessage
-                id="energyCalculator.calculateImpact.results.emissionsImpact.description.reduction"
-                defaultMessage="Our modeling shows that homes like yours will tend to have annual emissions reductions between {low} and {high} lb CO₂e, with most homes reducing emissions by at least {mostLikely} lb."
-                values={{ low: emRangeLow, high: emRangeHigh, mostLikely: emMostLikely }}
-              />
-            ) : (
-              <FormattedMessage
-                id="energyCalculator.calculateImpact.results.emissionsImpact.description.increase"
-                defaultMessage="Our modeling shows that homes like yours will tend to see annual emissions increases between {low} and {high} lb CO₂e, with most homes seeing increases of at least {mostLikely} lb."
-                values={{ low: emRangeLow, high: emRangeHigh, mostLikely: emMostLikely }}
-              />
-            )}
-          </p>
-          <ImpactRangeBar
-            p20={emP20}
-            median={emMedian}
-            p80={emP80}
-            formatValue={(n) => formatEmissionsLbs(n)}
-            unitSuffix=" CO₂e/yr"
-          />
-
-          {/* EPA equivalencies */}
-          <div className="calculate-impact-epa-section">
-            <p className="calculate-impact-epa-intro">
-              <FormattedMessage
-                id="energyCalculator.calculateImpact.epa.intro"
-                defaultMessage="This is equivalent to carbon sequestered by:"
+                id="energyCalculator.calculateImpact.results.billImpact.however"
+                defaultMessage="However, your utility bill could increase if you are adding air conditioning to a home that did not have it before."
               />
             </p>
-            <div className="calculate-impact-epa-chips">
-              {equivalencies.map((eq) => (
-                <Chip
-                  key={eq.id}
-                  icon={<ForestIcon />}
-                  label={
+            <ImpactRangeBar
+              p20={billP20}
+              median={billMedian}
+              p80={billP80}
+              formatValue={(n) => formatToUSD(n)}
+              unitSuffix="/yr"
+            />
+          </div>
+
+          {/* Emissions impact */}
+          <div className="calculate-impact-impact-section">
+            <h3 className="calculate-impact-impact-title">
+              <FormattedMessage
+                id="energyCalculator.calculateImpact.results.emissionsImpact.title"
+                defaultMessage="Emissions impact"
+              />
+            </h3>
+            <p className="calculate-impact-impact-description">
+              {emMedian <= 0 ? (
+                <FormattedMessage
+                  id="energyCalculator.calculateImpact.results.emissionsImpact.description.reduction"
+                  defaultMessage="Our modeling shows that homes like yours will tend to have annual emissions reductions between {low} and {high} lb CO₂e, with most homes reducing emissions by at least {mostLikely} lb."
+                  values={{ low: emRangeLow, high: emRangeHigh, mostLikely: emMostLikely }}
+                />
+              ) : (
+                <FormattedMessage
+                  id="energyCalculator.calculateImpact.results.emissionsImpact.description.increase"
+                  defaultMessage="Our modeling shows that homes like yours will tend to see annual emissions increases between {low} and {high} lb CO₂e, with most homes seeing increases of at least {mostLikely} lb."
+                  values={{ low: emRangeLow, high: emRangeHigh, mostLikely: emMostLikely }}
+                />
+              )}
+            </p>
+            <ImpactRangeBar
+              p20={emP20}
+              median={emMedian}
+              p80={emP80}
+              formatValue={(n) => formatEmissionsLbs(n)}
+              unitSuffix=" CO₂e/yr"
+            />
+
+            {/* EPA equivalencies */}
+            <div className="calculate-impact-epa-section">
+              <p className="calculate-impact-epa-intro">
+                <FormattedMessage
+                  id="energyCalculator.calculateImpact.epa.intro"
+                  defaultMessage="This is equivalent to carbon sequestered by:"
+                />
+              </p>
+              <div className="calculate-impact-epa-chips">
+                {equivalencies.map((eq) => (
+                  <span key={eq.id} className="calculate-impact-epa-badge">
+                    <ForestIcon className="calculate-impact-epa-badge-icon" />
                     <FormattedMessage
                       id={eq.labelMessageId}
                       defaultMessage={eq.labelDefaultMessage}
                       values={{ value: eq.value.toFixed(1) }}
                     />
-                  }
-                  className="calculate-impact-epa-chip"
+                  </span>
+                ))}
+              </div>
+              <p className="calculate-impact-epa-source">
+                <FormattedMessage
+                  id="energyCalculator.calculateImpact.epa.dataSourceLabel"
+                  defaultMessage="Data source: {source}"
+                  values={{
+                    source: intl.formatMessage({
+                      id: EPA_DATA_SOURCE_MESSAGE_ID,
+                      defaultMessage: EPA_DATA_SOURCE_DEFAULT_MESSAGE,
+                    }),
+                  }}
                 />
-              ))}
+              </p>
             </div>
-            <p className="calculate-impact-epa-source">
-              <FormattedMessage
-                id="energyCalculator.calculateImpact.epa.dataSourceLabel"
-                defaultMessage="Data source: {source}"
-                values={{
-                  source: intl.formatMessage({
-                    id: EPA_DATA_SOURCE_MESSAGE_ID,
-                    defaultMessage: EPA_DATA_SOURCE_DEFAULT_MESSAGE,
-                  }),
-                }}
-              />
-            </p>
           </div>
         </div>
       </section>

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/fetchRemImpact.ts
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/fetchRemImpact.ts
@@ -1,5 +1,7 @@
 import type { CalculateImpactRemAddressQuery, RemImpactApiResponse } from './remCalculateImpactTypes';
 
+const domain = process.env.REACT_APP_DOMAIN_URL;
+
 export async function fetchRemImpact(
   whiteLabel: string,
   query: CalculateImpactRemAddressQuery,
@@ -13,7 +15,7 @@ export async function fetchRemImpact(
     params.append('water_heater_fuel', query.water_heater_fuel);
   }
 
-  const res = await fetch(`/api/screener-options/${whiteLabel}/rem-impact/?${params.toString()}`);
+  const res = await fetch(`${domain}/api/screener-options/${whiteLabel}/rem-impact/?${params.toString()}`);
 
   if (!res.ok) {
     throw new Error(`REM API error: ${res.status}`);

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/fetchRemImpact.ts
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/fetchRemImpact.ts
@@ -1,0 +1,23 @@
+import type { CalculateImpactRemAddressQuery, RemImpactApiResponse } from './remCalculateImpactTypes';
+
+export async function fetchRemImpact(
+  whiteLabel: string,
+  query: CalculateImpactRemAddressQuery,
+): Promise<RemImpactApiResponse> {
+  const params = new URLSearchParams({
+    upgrade: query.upgrade,
+    address: query.address,
+    heating_fuel: query.heating_fuel,
+  });
+  if (query.water_heater_fuel) {
+    params.append('water_heater_fuel', query.water_heater_fuel);
+  }
+
+  const res = await fetch(`/api/screener-options/${whiteLabel}/rem-impact/?${params.toString()}`);
+
+  if (!res.ok) {
+    throw new Error(`REM API error: ${res.status}`);
+  }
+
+  return res.json() as Promise<RemImpactApiResponse>;
+}

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/remCalculateImpactTypes.test.ts
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/remCalculateImpactTypes.test.ts
@@ -1,10 +1,61 @@
 import {
   buildCalculateImpactPayload,
+  isValidRemImpactApiResponse,
   CALCULATE_IMPACT_UPGRADE_MAP,
   type CalculateImpactUpgradeChoice,
   type RemFuelType,
   type CalculateImpactHouseholdType,
 } from './remCalculateImpactTypes';
+
+// ─── Shared fixture ────────────────────────────────────────────────────────────
+
+const VALID_STAT = { value: -21.9, unit: '$' };
+const VALID_RANGE = {
+  mean: VALID_STAT,
+  median: VALID_STAT,
+  percentile_20: VALID_STAT,
+  percentile_80: VALID_STAT,
+};
+const VALID_RESPONSE = { bill_delta: VALID_RANGE, emissions_delta: VALID_RANGE };
+
+describe('isValidRemImpactApiResponse', () => {
+  it('returns true for a well-formed response', () => {
+    expect(isValidRemImpactApiResponse(VALID_RESPONSE)).toBe(true);
+  });
+
+  it('returns false for null / undefined', () => {
+    expect(isValidRemImpactApiResponse(null)).toBe(false);
+    expect(isValidRemImpactApiResponse(undefined)).toBe(false);
+  });
+
+  it('returns false when bill_delta is missing entirely', () => {
+    expect(isValidRemImpactApiResponse({ emissions_delta: VALID_RANGE })).toBe(false);
+  });
+
+  it('returns false when a percentile key is absent from bill_delta', () => {
+    const missingPercentile = {
+      ...VALID_RESPONSE,
+      bill_delta: { mean: VALID_STAT, median: VALID_STAT, percentile_20: VALID_STAT },
+    };
+    expect(isValidRemImpactApiResponse(missingPercentile)).toBe(false);
+  });
+
+  it('returns false when a stat value is null (backend defensive default becomes 0, but upstream could send null)', () => {
+    const nullValue = {
+      ...VALID_RESPONSE,
+      bill_delta: { ...VALID_RANGE, median: { value: null, unit: '$' } },
+    };
+    expect(isValidRemImpactApiResponse(nullValue)).toBe(false);
+  });
+
+  it('returns false when a stat value is a string instead of a number', () => {
+    const stringValue = {
+      ...VALID_RESPONSE,
+      emissions_delta: { ...VALID_RANGE, percentile_80: { value: '-430', unit: 'lbCO2e' } },
+    };
+    expect(isValidRemImpactApiResponse(stringValue)).toBe(false);
+  });
+});
 
 describe('CALCULATE_IMPACT_UPGRADE_MAP', () => {
   it('maps heat_pump to the correct REM upgrade', () => {

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/remCalculateImpactTypes.ts
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/remCalculateImpactTypes.ts
@@ -23,6 +23,30 @@ export interface RemImpactApiResponse {
   emissions_delta: RemImpactRange;  // annual CO₂e delta in lbCO2e; negative = reduction
 }
 
+const RANGE_KEYS: ReadonlyArray<keyof RemImpactRange> = ['mean', 'median', 'percentile_20', 'percentile_80'];
+
+/**
+ * Guards against a partial RA response (e.g. a missing percentile key) that
+ * would otherwise cause a TypeError in CalculateImpactResults at render time —
+ * after the promise has already resolved and past the .catch() that shows the
+ * error Alert. Call this before setSubmitState({ status: 'success' }).
+ */
+export function isValidRemImpactApiResponse(data: unknown): data is RemImpactApiResponse {
+  if (!data || typeof data !== 'object') return false;
+  const d = data as Record<string, unknown>;
+  for (const delta of ['bill_delta', 'emissions_delta'] as const) {
+    const range = d[delta];
+    if (!range || typeof range !== 'object') return false;
+    const r = range as Record<string, unknown>;
+    for (const key of RANGE_KEYS) {
+      const stat = r[key];
+      if (!stat || typeof stat !== 'object') return false;
+      if (typeof (stat as Record<string, unknown>)['value'] !== 'number') return false;
+    }
+  }
+  return true;
+}
+
 // ─── Form values (shared between form and results summary) ───────────────────
 
 export interface CalculateImpactFormValues {

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/remCalculateImpactTypes.ts
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/remCalculateImpactTypes.ts
@@ -3,6 +3,59 @@
  * GET /api/v1/rem/address — see https://docs.rewiringamerica.org/api/residential-electrification-model
  */
 
+// ─── Backend response types ───────────────────────────────────────────────────
+
+export interface RemImpactStat {
+  value: number;
+  unit: string; // '$' for bill_delta; 'lbCO2e' for emissions_delta (converted by backend)
+}
+
+export interface RemImpactRange {
+  mean: RemImpactStat;
+  median: RemImpactStat;
+  percentile_20: RemImpactStat;
+  percentile_80: RemImpactStat;
+}
+
+/** Response shape from GET /api/screener-options/<white_label>/rem-impact/ */
+export interface RemImpactApiResponse {
+  bill_delta: RemImpactRange;       // annual cost delta in $; negative = savings
+  emissions_delta: RemImpactRange;  // annual CO₂e delta in lbCO2e; negative = reduction
+}
+
+// ─── Form values (shared between form and results summary) ───────────────────
+
+export interface CalculateImpactFormValues {
+  householdType: CalculateImpactHouseholdType;
+  address: string;
+  heatingFuel: RemFuelType;
+  waterHeatingFuel?: RemFuelType;
+  upgradeChoice: CalculateImpactUpgradeChoice;
+}
+
+// ─── Display label lookup maps (used by CalculateImpactResults summary card) ─
+
+export const HOUSEHOLD_TYPE_LABEL_MAP: Record<CalculateImpactHouseholdType, { messageId: string; defaultMessage: string }> = {
+  single_family_detached: { messageId: 'energyCalculator.calculateImpact.householdType.singleFamilyDetached', defaultMessage: 'House' },
+  apartment_condo: { messageId: 'energyCalculator.calculateImpact.householdType.apartmentCondo', defaultMessage: 'Apartment' },
+  mobile_home: { messageId: 'energyCalculator.calculateImpact.householdType.mobileHome', defaultMessage: 'Mobile home' },
+  single_family_attached: { messageId: 'energyCalculator.calculateImpact.householdType.singleFamilyAttached', defaultMessage: 'Townhome' },
+};
+
+export const FUEL_TYPE_LABEL_MAP: Record<RemFuelType, { messageId: string; defaultMessage: string }> = {
+  electricity: { messageId: 'energyCalculator.calculateImpact.fuel.electricity', defaultMessage: 'Electricity' },
+  natural_gas: { messageId: 'energyCalculator.calculateImpact.fuel.naturalGas', defaultMessage: 'Natural gas' },
+  fuel_oil: { messageId: 'energyCalculator.calculateImpact.fuel.fuelOil', defaultMessage: 'Fuel oil' },
+  propane: { messageId: 'energyCalculator.calculateImpact.fuel.propane', defaultMessage: 'Propane' },
+};
+
+export const UPGRADE_LABEL_MAP: Record<CalculateImpactUpgradeChoice, { messageId: string; defaultMessage: string }> = {
+  heat_pump: { messageId: 'energyCalculator.calculateImpact.upgrade.heatPump', defaultMessage: 'Heat pump' },
+  weatherization: { messageId: 'energyCalculator.calculateImpact.upgrade.weatherization', defaultMessage: 'Weatherization' },
+  heat_pump_weatherization: { messageId: 'energyCalculator.calculateImpact.upgrade.heatPumpWeatherization', defaultMessage: 'Heat pump + weatherization' },
+  heat_pump_water_heater: { messageId: 'energyCalculator.calculateImpact.upgrade.heatPumpWaterHeater', defaultMessage: 'Heat pump water heater' },
+};
+
 /** `upgrade` query param on /api/v1/rem/address */
 export type RemUpgrade =
   | 'hvac__heat_pump_seer24_hspf13'

--- a/src/utils/epaEquivalencies.test.ts
+++ b/src/utils/epaEquivalencies.test.ts
@@ -1,0 +1,41 @@
+import { getEpaEquivalencies } from './epaEquivalencies';
+
+const LBS_PER_METRIC_TON = 2204.62;
+
+describe('getEpaEquivalencies', () => {
+  describe('forest_acres', () => {
+    it('returns 1 acre for exactly 1 metric ton of CO₂e (2204.62 lb)', () => {
+      const [result] = getEpaEquivalencies(-LBS_PER_METRIC_TON);
+      expect(result.id).toBe('forest_acres');
+      expect(result.value).toBeCloseTo(1.0, 4);
+    });
+
+    it('uses the absolute value so negative emissions (reductions) work correctly', () => {
+      const [neg] = getEpaEquivalencies(-LBS_PER_METRIC_TON * 3);
+      const [pos] = getEpaEquivalencies(LBS_PER_METRIC_TON * 3);
+      expect(neg.value).toBeCloseTo(pos.value, 4);
+    });
+
+    it('returns 0 for zero emissions', () => {
+      const [result] = getEpaEquivalencies(0);
+      expect(result.value).toBe(0);
+    });
+
+    it('scales linearly', () => {
+      const [single] = getEpaEquivalencies(-LBS_PER_METRIC_TON);
+      const [double] = getEpaEquivalencies(-LBS_PER_METRIC_TON * 2);
+      expect(double.value).toBeCloseTo(single.value * 2, 4);
+    });
+
+    it('includes the correct i18n message ID', () => {
+      const [result] = getEpaEquivalencies(-1000);
+      expect(result.labelMessageId).toBe('energyCalculator.calculateImpact.epa.forestAcres');
+    });
+  });
+
+  it('returns one result per defined equivalency', () => {
+    const results = getEpaEquivalencies(-5000);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((r) => typeof r.value === 'number')).toBe(true);
+  });
+});

--- a/src/utils/epaEquivalencies.ts
+++ b/src/utils/epaEquivalencies.ts
@@ -1,0 +1,54 @@
+// EPA Greenhouse Gas Equivalencies Calculator
+// https://www.epa.gov/energy/greenhouse-gas-equivalencies-calculator-calculations-and-references
+// Page last updated: 2026-03-30. Retrieved: 2026-06-03.
+//
+// 1 acre of average U.S. forest sequesters 1.00 metric ton CO₂/yr
+// Derivation: -0.27 metric ton C/acre/yr × (44 CO₂ / 12 C) = -1.00 metric ton CO₂/acre/yr
+
+const LBS_PER_METRIC_TON = 2204.62;
+const LBS_CO2E_PER_FOREST_ACRE_PER_YEAR = 1.0 * LBS_PER_METRIC_TON; // 2204.62 lb CO₂e
+
+export interface EpaEquivalencyResult {
+  id: string;
+  value: number;
+  labelMessageId: string;
+  labelDefaultMessage: string;
+}
+
+// Each entry defines one EPA equivalency. Add new entries here to enable them in the UI.
+// Only forest_acres is shown per the Step 3 design (MFB-981). Future entries are stubbed below.
+const EPA_EQUIVALENCIES = [
+  {
+    id: 'forest_acres',
+    convert: (lbsCO2e: number): number => Math.abs(lbsCO2e) / LBS_CO2E_PER_FOREST_ACRE_PER_YEAR,
+    labelMessageId: 'energyCalculator.calculateImpact.epa.forestAcres',
+    labelDefaultMessage: '{value} acres of U.S. forests in one year',
+  },
+  // To add more equivalencies, append entries here, e.g.:
+  // {
+  //   id: 'miles_driven',
+  //   // EPA: 8,887 g CO₂/gallon × 1 gallon/22.3 miles ≈ 0.000404 metric tons CO₂/mile
+  //   convert: (lbs) => Math.abs(lbs) / (0.000404 * LBS_PER_METRIC_TON),
+  //   labelMessageId: 'energyCalculator.calculateImpact.epa.milesDriven',
+  //   labelDefaultMessage: '{value} miles driven by an average passenger car',
+  // },
+  // {
+  //   id: 'gallons_gasoline',
+  //   // EPA: 8,887 g CO₂/gallon of gasoline
+  //   convert: (lbs) => Math.abs(lbs) / (8.887 / 1000 * LBS_PER_METRIC_TON / 1000),
+  //   labelMessageId: 'energyCalculator.calculateImpact.epa.gallonsGasoline',
+  //   labelDefaultMessage: '{value} gallons of gasoline burned',
+  // },
+];
+
+export const EPA_DATA_SOURCE_MESSAGE_ID = 'energyCalculator.calculateImpact.epa.dataSource';
+export const EPA_DATA_SOURCE_DEFAULT_MESSAGE = "EPA's Greenhouse Gas Equivalencies Calculator";
+
+export function getEpaEquivalencies(emissionsLbsCO2e: number): EpaEquivalencyResult[] {
+  return EPA_EQUIVALENCIES.map((eq) => ({
+    id: eq.id,
+    value: eq.convert(emissionsLbsCO2e),
+    labelMessageId: eq.labelMessageId,
+    labelDefaultMessage: eq.labelDefaultMessage,
+  }));
+}


### PR DESCRIPTION
## Context & Motivation

- Related to Linear ticket MFB-981 (Heat Pump Step 3: Wire Rewiring America API + EPA equivalencies for heat pump water heater)
- The CESN Calculate Impact page (built in MFB-979) had a working form UI but a no-op submit handler. This PR wires the frontend half of the integration — calling the new backend REM proxy endpoint (added in the companion `benefits-api` PR), rendering the results view, and displaying EPA carbon equivalencies.
- All new UI is gated behind the existing `cesn_heat_pump_journey` feature flag.

## Changes Made

- **`src/utils/epaEquivalencies.ts`** (new): Pure TypeScript utility that converts lb CO₂e to EPA equivalency values. Currently implements one equivalency — acres of U.S. forests sequestering carbon for one year — using the EPA's published factor of 1.00 metric ton CO₂/acre/yr (source cited in file). Future equivalencies (miles driven, gallons of gasoline, etc.) are stubbed as comments and can be enabled by appending entries to the `EPA_EQUIVALENCIES` array.
- **`src/utils/epaEquivalencies.test.ts`** (new): 6 unit tests covering the forest acres conversion — correct value for 1 metric ton, absolute value behavior, zero, linear scaling, and message ID.
- **`src/Components/EnergyCalculator/Results/HeatPumpJourney/remCalculateImpactTypes.ts`** (modified): Added `RemImpactStat`, `RemImpactRange`, and `RemImpactApiResponse` interfaces matching the backend endpoint's response shape. Added `CalculateImpactFormValues` interface (shared between the form and results summary). Added `HOUSEHOLD_TYPE_LABEL_MAP`, `FUEL_TYPE_LABEL_MAP`, and `UPGRADE_LABEL_MAP` lookup objects used by the results summary card.
- **`src/Components/EnergyCalculator/Results/HeatPumpJourney/fetchRemImpact.ts`** (new): Async function that calls `GET /api/screener-options/<white_label>/rem-impact/` with the form payload and returns a typed `RemImpactApiResponse`.
- **`src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactResults.tsx`** (new): Full results view rendered after a successful API call. Contains three sections:
  - **"Your household info" summary card** — displays submitted form values (household type, address, heating fuel, water heating fuel if provided) with a pencil icon that returns the user to the pre-populated form.
  - **"Selected upgrade"** — displays the chosen upgrade type.
  - **"Bill and emissions impact" card** — two subsections (Energy bill impact, Emissions impact), each with a description paragraph and a custom `ImpactRangeBar` component. Below the emissions bar: EPA equivalency chip (forest acres) and data source citation.
  - `ImpactRangeBar` is an inline sub-component that renders a colored horizontal range bar (green for savings/reduction, red for cost increase), a centered median marker with value label, and end labels for `percentile_80` (left, least favorable) and `percentile_20` (right, most favorable).
- **`src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.tsx`** (modified):
  - Added `useFeatureFlag('cesn_heat_pump_journey')` gate — returns `null` when the flag is off.
  - Added a `SubmitState` discriminated union (`idle | loading | success | error`) and wired `onSubmit` to call `fetchRemImpact`, transitioning through states accordingly.
  - On `success`, renders the full page header/intro (reusing existing markup) followed by `<CalculateImpactResults>`. The edit button sets state back to `idle`, returning to the pre-populated form.
  - On `loading`, renders a `CircularProgress` spinner above the form.
  - On `error`, renders an MUI `Alert` above the form.
  - Non-HPWH upgrade radio options (`heat_pump`, `weatherization`, `heat_pump_weatherization`) are now `disabled` with a "Coming soon" label; only `heat_pump_water_heater` is selectable.
- **`src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.css`** (modified): Added styles for the "Coming soon" badge, loading/error states, results layout, household summary card, selected upgrade row, range bar (track, fill colors, median float label, end labels), and EPA equivalency chip.

## Testing

- Migrations to run: None
- Configuration updates needed: Ensure the `cesn_heat_pump_journey` feature flag is enabled in the white label config for the environment you're testing against
- Environment variables/settings to add: None (the `benefits-api` companion PR handles `REWIRING_AMERICA_API_KEY`)
- Manual testing steps:
  1. Start the backend (`benefits-api`) and frontend (`benefits-calculator`) dev servers
  2. Navigate to the CESN Calculate Impact page: `/{whiteLabel}/{uuid}/results/energy-rebates/waterHeater/calculate-impact`
  3. Verify non-HPWH upgrade options show "Coming soon" and are not selectable
  4. Fill in the form with "Heat pump water heater" selected and submit
  5. Confirm the loading spinner appears during the request
  6. Confirm the results view renders with:
     - Household info summary card matching submitted values
     - Edit pencil returning to the pre-populated form
     - "Selected upgrade" showing "Heat pump water heater"
     - Bill impact range bar with colored segments and median label
     - Emissions impact range bar
     - EPA equivalency chip showing forest acres
     - Data source citation
  7. Test error state by temporarily breaking the API URL in `fetchRemImpact.ts` and confirming the error alert renders
  8. Confirm the page returns `null` (renders nothing) when `cesn_heat_pump_journey` flag is off
  9. Run unit tests: `npm test -- --testPathPattern="epaEquivalencies"`

## Deployment

- Run script: None
- Update production config: Enable `cesn_heat_pump_journey` feature flag on the CESN white label when ready to go live (flag is currently `false` in production — this PR does not change that)
- Admin updates needed: None
- Notify team/users of: None — the page remains unreachable via normal navigation until the feature flag is enabled

## Notes for Reviewers

- Known limitations: The bill impact description copy ("will tend to save between X and Y") assumes the median delta is negative (net savings). For the heat pump water heater upgrade this is almost always true, but if `bill_delta.median.value` is positive (net cost increase), the copy will be inaccurate. This edge case can be handled in a follow-up.
- Known limitations: `ImpactRangeBar` is co-located inline in `CalculateImpactResults.tsx` rather than its own file. If the range bar is reused in Step 4 or beyond, it should be extracted to its own component file at that point.
- Future considerations: Step 4 (MFB-982) will enable the remaining three upgrade types. This can be done by updating the `isAvailable` check in `CalculateImpactPage.tsx` from `opt.value === 'heat_pump_water_heater'` to include the additional types as they are wired.
- Future considerations: Additional EPA equivalencies (miles driven, gallons of gasoline) can be enabled by appending entries to the `EPA_EQUIVALENCIES` array in `src/utils/epaEquivalencies.ts` — no other code changes required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Heat pump “Calculate Impact” results view with bill/emissions impacts, percentile ranges, median marker, EPA equivalency chips, and data-source label.
  * Remote impact request flow powering the results and an edit/back-to-results action.

* **UI / Style**
  * New results layout styles, full-range impact bar, summary cards, loading/error layouts, and “Coming soon” badges for unavailable upgrades.

* **Behavior**
  * Journey gated by feature flag; upgrade choices limited to heat pump water heater, water-heating fuel validated, submit shows spinner/aria-busy and error alerts.

* **Tests**
  * Added EPA equivalency unit tests and expanded results/page tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->