### PR TITLE
MFB-921: Fixing has_wap persistence issue

### DIFF
--- a/src/Assets/updateFormData.tsx
+++ b/src/Assets/updateFormData.tsx
@@ -92,7 +92,7 @@ export function useUpdateFormData() {
         cowap: response.has_cowap ?? false,
         cesn_cowap: response.has_cowap ?? false,
         ncwap: response.has_ncwap ?? false,
-        wa_wap: response.has_wap ?? false,
+        wa_wap: response.has_wa_wap ?? false,
         ubp: response.has_ubp ?? false,
         nfp: response.has_nfp ?? false,
         fatc: response.has_fatc ?? false,

--- a/src/Assets/updateScreen.ts
+++ b/src/Assets/updateScreen.ts
@@ -80,7 +80,7 @@ const getScreensBody = (formData: FormData, languageCode: Language, whiteLabel: 
     has_nc_medicare_savings: formData.benefits.nc_medicare_savings ?? null,
     has_nc_lieap: formData.benefits.nc_lieap ?? null,
     has_ncwap: formData.benefits.ncwap ?? null,
-    has_wap: formData.benefits.wa_wap ?? null,
+    has_wa_wap: formData.benefits.wa_wap ?? null,
     has_nccip: formData.benefits.nccip ?? null,
     has_ccdf: formData.benefits.ccdf ?? null,
     has_aca: formData.benefits.aca || formData.benefits.nc_aca || null,

--- a/src/Types/ApiFormData.ts
+++ b/src/Types/ApiFormData.ts
@@ -194,7 +194,7 @@ export type ApiFormData = {
   has_ssdi: boolean | null;
   has_cowap: boolean | null;
   has_ncwap: boolean | null;
-  has_wap: boolean | null;
+  has_wa_wap: boolean | null;
   has_ubp: boolean | null;
   has_pell_grant: boolean | null;
   has_nfp: boolean | null;


### PR DESCRIPTION
# MFB-921 — Fix WA Weatherization (WAP) existing-benefit not persisting

## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

During Prod QA of the WA Weatherization Assistance Program (WAP), Scenario 8 ("household already
receiving WAP → should be excluded/Not eligible") could not be exercised: selecting **Weatherization
Assistance Program (WAP)** on the Existing Benefits step (Step 8) never persisted. Toggling it on set
`aria-pressed=true`, but after Continue the confirmation page showed "Current Household Benefits: None"
and the option reverted to unselected.

Root cause: a **frontend/backend field-name mismatch**. The backend Screen model column is
**`has_wa_wap`** (`benefits-api/screener/models.py`), and the Screen serializer reads/writes
`has_wa_wap` (`benefits-api/screener/serializers.py`). The frontend, however, wrote and read
**`has_wap`** — a field that does not exist on the backend:

- **Write** (`updateScreen.ts`): sent `has_wap`, which the serializer ignores as an unknown key, so
  `has_wa_wap` stayed `False` → selection never saved.
- **Hydrate** (`updateFormData.tsx`): read `response.has_wap` (always `undefined`) → `?? false` → the
  tile always rendered unselected on load.

User-facing impact: any WA resident who indicated they already receive Weatherization had that input
silently dropped, so the screener could not suppress WAP for households that already have it (they
would keep seeing WAP as an eligible "new benefit").

- Fixes #[MFB-921]
- Related PR: [link if applicable]

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

Frontend only (`benefits-calculator`), aligning the WAP key to the backend's `has_wa_wap` column:

- `src/Assets/updateScreen.ts` — write path: `has_wap: formData.benefits.wa_wap` → `has_wa_wap: formData.benefits.wa_wap`
- `src/Assets/updateFormData.tsx` — hydrate path: `wa_wap: response.has_wap ?? false` → `wa_wap: response.has_wa_wap ?? false`
- `src/Types/ApiFormData.ts` — request body type: `has_wap: boolean | null` → `has_wa_wap: boolean | null`

No backend changes — the backend already used `has_wa_wap` correctly (model, serializer, and the
`wa_wap` calculator-input mapping in `serializers.py`).

## Testing

<!-- Steps needed to test this PR locally -->

- **Migrations to run:** None
- **Configuration updates needed:** None
- **Environment variables/settings to add:** None
- **Manual testing steps:**

  Prereq: run the `benefits-calculator` dev server on this branch (`npm start`, http://localhost:3000)
  pointed at an API whose backend has the `has_wa_wap` column (staging API works; local Django works).

  1. **Type-check:** `npx tsc --noEmit` — the change introduces no new TypeScript errors (the only
     pre-existing errors are unrelated `*.test.tsx` issues and a `tsconfig.json` `allowImportingTsExtensions`
     warning).
  2. **Persistence:** Start a WA screen (`/wa`), reach **Step 8 (Existing Benefits)**, select
     **Weatherization Assistance Program (WAP)**, click **Continue**, then return to Step 8 (or open
     `/wa/{uuid}/confirm-information`). WAP should remain **selected** / appear under "Current Household
     Benefits". (Before the fix it reverted to unselected / showed "None".)
  3. **Suppression behavior (Scenario 8):** Using an income-eligible WA household (income under 200% FPL —
     e.g. HH=1 with ~$13k/yr, King County) **with WAP selected** as an existing benefit, submit and view
     results. WAP must **not** appear as an eligible "New Benefit" (it is correctly suppressed).
  4. **A/B control (proves causation):** On the same screen, **deselect** WAP on Step 8 → resubmit →
     WAP now appears as eligible ("Up to $7,669 per home"). Re-select WAP → resubmit → WAP disappears
     again. Toggling the flag flips results between suppressed and shown.

  Verified end-to-end on a local dev server against UUID `5c6a4f48-991a-4e49-aa93-199ca92b214f`:
  WAP-selected → 6 programs, WAP suppressed; WAP-deselected → 7 programs, WAP shown at $7,669.

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- **Run script:** None
- **Update production config:** None
- **Admin updates needed:** None
- **Notify team/users of:** The WAP existing-benefit checkbox now functions for WA users; previously
  it was silently discarded. After deploy, re-run Scenario 8 against staging/prod
  (`/playwright-qa-execution MFB-921 staging`) to confirm in the deployed bundle.
- **Note:** This is a frontend bundle change — it is not live until `benefits-calculator` is rebuilt
  and deployed. Production/staging serve the previously built bundle until then.

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- **Known limitations:**
  - `wa_wap` is intentionally **not** added to `BENEFIT_SIBLING_GROUPS` (`src/Assets/benefitSiblings.ts`)
    — WAP maps 1:1 to a single `has_wa_wap` column with no sibling variant keys, so `getBenefitSiblings`
    correctly returns `['wa_wap']`. The earlier suspicion that a missing sibling group caused this was a
    red herring; the field-name mismatch was the actual cause.
- **Future considerations:**
  - This whole class of `formData.benefits` key ↔ `has_*` column mismatch goes away with the
    MFB-720 join-table migration (referenced in `benefitSiblings.ts`), after which frontend keys mirror
    `name_abbreviated` 1:1. Until then, every new benefit needs its `updateScreen.ts` / `updateFormData.tsx`
    / `ApiFormData.ts` keys checked against the backend column name — a quick audit for other WA/state
    benefits would be worthwhile to catch any similar typos.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the mapping of benefits field data to ensure accurate information is processed and saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->