### PR TITLE
MFB-1169: Fix estimation card alignment when value wraps to two lines

### DIFF
--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -93,6 +93,7 @@
   margin-bottom: 1rem;
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
   width: 100%;
   padding-bottom: 0.2rem;
   border-bottom: 0.07rem solid white;
@@ -101,6 +102,11 @@
 .estimation-text-left {
   text-align: left;
   margin-right: 2rem;
+}
+
+.estimation-text-right {
+  flex: 1;
+  text-align: right;
 }
 
 .apply-button-container {

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -190,7 +190,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
           <article className="estimation-text-left">
             <FormattedMessage id="results.estimated-time-to-apply" defaultMessage="Estimated Time to Apply" />
           </article>
-          <article className="slim-text">
+          <article className="estimation-text-right slim-text">
             <ResultsTranslate translation={program.estimated_application_time} />
           </article>
         </div>


### PR DESCRIPTION
## Summary

Fixes the orange estimation card on the program results detail page, which misaligned whenever a value wrapped to a second line. When values fit on one line the card already looked fine.

Reported via: https://screener.myfriendben.org/wa/9b15148b-ed81-4363-a532-349421578ca7/results/benefits/397

Linear: [MFB-1169](https://linear.app/myfriendben/issue/MFB-1169/fix-program-results-card-misaligns-when-estimated-time-to-apply-value)

## Root cause

In 'src/Components/Results/ProgramPage/ProgramPage.css', '.estimation-text' is a flex row with 'justify-content: space-between' but no 'align-items' (defaults to 'stretch'), and the value columns had no 'text-align'. So when a value wrapped, the wrapped lines rendered ragged-left and the left label drifted vertically out of line with the value's first line.

Additionally, the "Estimated Time to Apply" value '<article>' was missing the 'estimation-text-right' class entirely — and that's the row that wraps in practice ("30 – 90 minutes", "1 - 2 hours").

## Fix

- 'align-items: flex-start' on the row so both labels anchor to the value's first line.
- 'flex: 1; text-align: right' on '.estimation-text-right' so wrapped value lines stack cleanly against the card edge.
- Add 'estimation-text-right' to the time-to-apply value column for consistency.

Single-line cards render unchanged.

<img width="952" height="325" alt="image" src="https://github.com/user-attachments/assets/fdd7461c-2ffd-458e-9e69-2dea43e2a506" />


## Before / After

Validated in an isolated harness reproducing the exact card markup + CSS in the wrapping case:

- **Before:** wrapped value lines ragged-left, label vertically offset.
- **After:** labels top-aligned with the value's first line; wrapped value text right-aligned against the card edge.

## Test plan

- [ ] On a WA program with a wrapping time value (e.g. results/benefits/397), confirm label + value are top-aligned and the wrapped value is right-aligned.
- [ ] Confirm single-line cards are visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual layout and alignment of the "Estimated Time to Apply" section on program detail pages. The estimated time value now displays with proper right-alignment and optimized spacing, enhancing visual clarity and the overall presentation of program information. These refinements ensure better readability and a more polished user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->