### PR TITLE
Restore Rewiring America link in Calculate Impact intro

### DIFF
--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.test.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.test.tsx
@@ -95,7 +95,8 @@ describe('CalculateImpactPage', () => {
 
     it('renders the Rewiring America intro paragraph', () => {
       renderPage();
-      expect(screen.getByText(/this data modeling is by rewiring america/i)).toBeInTheDocument();
+      expect(screen.getByText(/this data modeling is by/i)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /rewiring america/i })).toBeInTheDocument();
     });
 
     it('renders the BACK TO RESULTS button', () => {

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactPage.tsx
@@ -19,6 +19,7 @@ import {
 } from '@mui/material';
 import LeftArrowIcon from '@mui/icons-material/KeyboardArrowLeft';
 import { Alert, CircularProgress } from '@mui/material';
+import { TrackedOutboundLink } from '../../../Common/TrackedOutboundLink';
 import { usePageTitle } from '../../../Common/usePageTitle';
 import { OTHER_PAGE_TITLES } from '../../../../Assets/pageTitleTags';
 import { addAdminToLink } from '../../../../Assets/adminLink';
@@ -263,7 +264,20 @@ export default function CalculateImpactPage() {
         <Typography variant="body1" className="calculate-impact-intro energy-calculator-body-text">
           <FormattedMessage
             id="energyCalculator.calculateImpact.intro"
-            defaultMessage="This data modeling is by Rewiring America, an independent nonprofit that supports customers accessing electrification rebates and home energy upgrades. It provides a range of the impact of your selected upgrade on your energy bill, and emissions reductions estimates for your project."
+            defaultMessage="This data modeling is by {rewiringAmerica}, an independent nonprofit that supports customers accessing electrification rebates and home energy upgrades. It provides a range of the impact of your selected upgrade on your energy bill, and emissions reductions estimates for your project."
+            values={{
+              rewiringAmerica: (
+                <TrackedOutboundLink
+                  href="https://www.rewiringamerica.org"
+                  className="link-color"
+                  action="calculate_impact_rewiring_america"
+                  label="Rewiring America"
+                  category="energy_rebate"
+                >
+                  <FormattedMessage id="co.energy.rewiring_america_link" defaultMessage="Rewiring America" />
+                </TrackedOutboundLink>
+              ),
+            }}
           />
         </Typography>
 
@@ -314,7 +328,20 @@ export default function CalculateImpactPage() {
       <Typography variant="body1" className="calculate-impact-intro energy-calculator-body-text">
         <FormattedMessage
           id="energyCalculator.calculateImpact.intro"
-          defaultMessage="This data modeling is by Rewiring America, an independent nonprofit that supports customers accessing electrification rebates and home energy upgrades. It provides a range of the impact of your selected upgrade on your energy bill, and emissions reductions estimates for your project."
+          defaultMessage="This data modeling is by {rewiringAmerica}, an independent nonprofit that supports customers accessing electrification rebates and home energy upgrades. It provides a range of the impact of your selected upgrade on your energy bill, and emissions reductions estimates for your project."
+          values={{
+            rewiringAmerica: (
+              <TrackedOutboundLink
+                href="https://www.rewiringamerica.org"
+                className="link-color"
+                action="calculate_impact_rewiring_america"
+                label="Rewiring America"
+                category="energy_rebate"
+              >
+                <FormattedMessage id="co.energy.rewiring_america_link" defaultMessage="Rewiring America" />
+              </TrackedOutboundLink>
+            ),
+          }}
         />
       </Typography>
 


### PR DESCRIPTION
## Summary
- Restores the `TrackedOutboundLink` to `https://www.rewiringamerica.org` for "Rewiring America" in the Calculate Impact page intro paragraph (both the form view and results view)
- Re-adds the `TrackedOutboundLink` import that was removed in #2133
- The `{rewiringAmerica}` ICU placeholder and `values` prop are restored; the updated intro copy from #2133 is kept

## Deployment
- Re-run `add_translations` for `energyCalculator.calculateImpact.intro` on staging and prod — the English text now contains `{rewiringAmerica}` again as a placeholder (the DB currently has the plain-text version from #2133)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attribution text for data modeling sources is now a clickable, tracked link to Rewiring America.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->