### PR TITLE
MFB-1183: CESN Heat Pump final copy updates

### DIFF
--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactResults.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactResults.tsx
@@ -307,7 +307,7 @@ export default function CalculateImpactResults({
         <p className="calculate-impact-section-description">
           <FormattedMessage
             id="energyCalculator.calculateImpact.results.description"
-            defaultMessage="We calculated the impact estimates below based on your selected upgrade, and data such as home age, size, number of bedrooms, and construction material that match property records for your home address."
+            defaultMessage="The estimates below are based on your selected upgrade, and data such as home age, size, number of bedrooms, and construction material that match property records for your home address."
           />
         </p>
 

--- a/src/Components/EnergyCalculator/Results/HeatPumpJourney/ConnectNowPage.tsx
+++ b/src/Components/EnergyCalculator/Results/HeatPumpJourney/ConnectNowPage.tsx
@@ -129,7 +129,7 @@ export default function ConnectNowPage() {
         <Typography id={pdfSectionHeadingId} variant="h2" component="h2" className="connect-now-pdf-heading">
           <FormattedMessage
             id="energyCalculator.connectNow.pdfSectionHeading"
-            defaultMessage="How to find a good HVAC contractor from Electrify Now."
+            defaultMessage="How to find a good HVAC contractor, from Electrify Now."
           />
         </Typography>
         <PagedDocumentViewer

--- a/src/Components/EnergyCalculator/Results/rebateTypes.tsx
+++ b/src/Components/EnergyCalculator/Results/rebateTypes.tsx
@@ -256,28 +256,6 @@ export const renderCategoryDescription = (rebateType: EnergyCalculatorRebateCate
       return (
         <article className="category-description-article">
           {renderSharedHeatPumpContent()}
-          <p className="energy-calculator-p-spacing">
-            <FormattedMessage
-              id="co.energy.heat_pump_xcel_p3"
-              defaultMessage="Consult with an {contractorLink} to determine your heat pump unit size and potential rebate."
-              values={{
-                contractorLink: (
-                  <TrackedOutboundLink
-                    href="https://hvacree.net/xcel-co/public_search.cfm"
-                    className="link-color"
-                    action="xcel_contractor_click"
-                    label="Xcel Energy Registered Contractor"
-                    category="energy_rebate"
-                  >
-                    <FormattedMessage
-                      id="co.energy.heat_pump_contractor_link_xcel"
-                      defaultMessage="Xcel Energy Registered Contractor"
-                    />
-                  </TrackedOutboundLink>
-                ),
-              }}
-            />
-          </p>
         </article>
       );
     }


### PR DESCRIPTION
## Context & Motivation

Final copy/wording updates for the CESN heat pump UX journey on the water heater results page.

- Implements [MFB-1183](https://linear.app/myfriendben/issue/MFB-1183/cesn-heat-pump-final-copy-updates)

## Changes Made

1. **Calculate Impact intro** ([CalculateImpactResults.tsx](src/Components/EnergyCalculator/Results/HeatPumpJourney/CalculateImpactResults.tsx#L310)) — reworded from _"We calculated the impact estimates below based on your selected upgrade..."_ to _"The estimates below are based on your selected upgrade..."_
2. **Contractor guide heading** ([ConnectNowPage.tsx](src/Components/EnergyCalculator/Results/HeatPumpJourney/ConnectNowPage.tsx#L132)) — added a comma: _"How to find a good HVAC contractor**,** from Electrify Now."_
3. **Heat pump intro paragraph** ([rebateTypes.tsx](src/Components/EnergyCalculator/Results/rebateTypes.tsx#L255)) — removed the _"Consult with an [Xcel Energy Registered Contractor](https://hvacree.net/xcel-co/public_search.cfm) to determine your heat pump unit size and potential rebate."_ line from the Xcel-provider variant.

## Testing

- Migrations to run: none
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  - View the heat pump Calculate Impact results page → intro paragraph reads "The estimates below are based on..."
  - Open the Connect Now page → PDF section heading reads "How to find a good HVAC contractor, from Electrify Now."
  - View the HVAC category description for an Xcel-provider household → the "Consult with an Xcel Energy Registered Contractor..." line is gone.
- Automated: `react-scripts test` for `ConnectNowPage` (6 passed) and `CalculateImpactResults` (13 passed).

## Deployment

- Run script: none
- Update production config: none
- Admin updates needed: already updated in staging and prod
- Notify team/users of: none

## Notes for Reviewers

- Removing the Xcel consult line orphans the `co.energy.heat_pump_xcel_p3` and `co.energy.heat_pump_contractor_link_xcel` message IDs (no remaining code references); left translation cleanup out of scope.
- The Efficiency Works "Consult with a service provider" variant uses a different URL and was **not** touched — the ticket only called out the `hvacree.net/xcel-co` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated user-facing text descriptions for the "Bill and emissions impact" section.
  * Revised "PDF section heading" text formatting.
  * Removed provider-specific contractor outreach messaging from category descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->