### PR TITLE
MFB-1185: Always sort Tax Credits category to bottom of results

### DIFF
--- a/src/Components/Results/Programs/Programs.tsx
+++ b/src/Components/Results/Programs/Programs.tsx
@@ -20,6 +20,12 @@ function sortProgramsIntoCategories(categories: ProgramCategory[]): ProgramCateg
   const sortedCategories = categories
     .filter((category) => category.programs.length > 0)
     .sort((a, b) => {
+      // Temporary fix (MFB-1185): always push tax credit categories to the bottom,
+      // regardless of their priority or estimated value.
+      if (a.tax_category !== b.tax_category) {
+        return a.tax_category ? 1 : -1;
+      }
+
       const aPriority = a.priority === null ? Infinity : a.priority;
       const bPriority = b.priority === null ? Infinity : b.priority;
 


### PR DESCRIPTION
## Summary

Temporary fix ([MFB-1185](https://linear.app/myfriendben/issue/MFB-1185)) to keep the **Tax Credits** category pinned to the bottom of the results list.

Categories are sorted client-side in `sortProgramsIntoCategories` ([Programs.tsx](src/Components/Results/Programs/Programs.tsx)). Previously the order was driven by `priority` (ascending, `null` → last) and then total estimated value (descending). The tax credits category could land anywhere in that ordering.

This change makes `tax_category` the **primary** sort key, so any category with `tax_category === true` always sinks below all other categories — regardless of its `priority` or estimated value.

## Behavior

- Tax credit categories always render last.
- Ordering among all non-tax categories is unchanged (still `priority`, then total value).
- If multiple tax categories ever exist, they keep their relative priority/value ordering among themselves.

## Notes

This is intentionally a small, localized "temporary fix" per the ticket — it relies on the existing `tax_category` flag already returned by the API and the existing client-side sort, rather than adding new backend ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tax credit categories are now consistently displayed at the bottom of the program list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->