### PR TITLE
MFB-396: Update all icons to use Lucide library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/react-gtm-module": "^2.0.3",
         "@uiw/react-json-view": "^2.0.0-alpha.37",
         "libphonenumber-js": "^1.12.31",
+        "lucide-react": "^1.22.0",
         "nepali-number": "^1.0.3",
         "prettier": "^2.8.8",
         "react": "^18.0.0",
@@ -12515,6 +12516,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.22.0.tgz",
+      "integrity": "sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {
@@ -27315,6 +27325,12 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lucide-react": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.22.0.tgz",
+      "integrity": "sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg==",
+      "requires": {}
     },
     "lz-string": {
       "version": "1.4.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/react-gtm-module": "^2.0.3",
     "@uiw/react-json-view": "^2.0.0-alpha.37",
     "libphonenumber-js": "^1.12.31",
+    "lucide-react": "^1.22.0",
     "nepali-number": "^1.0.3",
     "prettier": "^2.8.8",
     "react": "^18.0.0",

--- a/src/Components/Config/configHook.tsx
+++ b/src/Components/Config/configHook.tsx
@@ -10,7 +10,7 @@ import { ReactComponent as HeartRate } from '../EnergyCalculator/Icons/HeartRate
 import { Language } from '../../Assets/languageOptions';
 import { Icon } from '../Icon/Icon';
 
-const OPTION_CARD_ICON_MAP: Record<string, string> = {
+export const OPTION_CARD_ICON_MAP: Record<string, string> = {
   // Health Insurance
   None: 'ban',
   Employer: 'briefcase',
@@ -38,8 +38,8 @@ const OPTION_CARD_ICON_MAP: Record<string, string> = {
   Legal_services: 'scale',
   Savings: 'piggy-bank',
   Military: 'shield',
-  Aging: 'circle-dot', // placeholder — mapping pending
-  Youth_development: 'circle-dot', // placeholder — mapping pending
+  Aging: 'tree-deciduous',
+  Youth_development: 'shapes',
 };
 
 

--- a/src/Components/Config/configHook.tsx
+++ b/src/Components/Config/configHook.tsx
@@ -4,36 +4,43 @@ import { configEndpoint, header } from '../../apiCalls';
 import { ConfigApiResponse, ConfigValue, FeatureFlags } from '../../Types/Config';
 import { Config } from '../../Types/Config';
 import { FormattedMessage } from 'react-intl';
-import { ReactComponent as Student } from '../../Assets/icons/General/OptionCard/Conditions/student.svg';
-import { ReactComponent as Pregnant } from '../../Assets/icons/General/OptionCard/Conditions/pregnant.svg';
-import { ReactComponent as BlindOrVisuallyImpaired } from '../../Assets/icons/General/OptionCard/Conditions/blindOrVisuallyImpaired.svg';
-import { ReactComponent as Disabled } from '../../Assets/icons/General/OptionCard/Conditions/disabled.svg';
-import { ReactComponent as LongTermDisability } from '../../Assets/icons/General/OptionCard/Conditions/longTermDisability.svg';
-import { ReactComponent as Chp } from '../../Assets/icons/General/OptionCard/HealthInsurance/chp.svg';
-import { ReactComponent as DontKnow } from '../../Assets/icons/General/OptionCard/HealthInsurance/dont_know.svg';
-import { ReactComponent as EmergencyMedicaid } from '../../Assets/icons/General/OptionCard/HealthInsurance/emergency_medicaid.svg';
-import { ReactComponent as Employer } from '../../Assets/icons/General/OptionCard/HealthInsurance/employer.svg';
-import { ReactComponent as FamilyPlanning } from '../../Assets/icons/UrgentNeeds/AcuteConditions/family_planning.svg';
-import { ReactComponent as Medicaid } from '../../Assets/icons/General/OptionCard/HealthInsurance/medicaid.svg';
-import { ReactComponent as Medicare } from '../../Assets/icons/General/OptionCard/HealthInsurance/medicare.svg';
-import { ReactComponent as None } from '../../Assets/icons/General/OptionCard/HealthInsurance/none.svg';
-import { ReactComponent as PrivateInsurance } from '../../Assets/icons/General/OptionCard/HealthInsurance/privateInsurance.svg';
-import { ReactComponent as BabySupplies } from '../../Assets/icons/UrgentNeeds/AcuteConditions/baby_supplies.svg';
-import { ReactComponent as ChildDevelopment } from '../../Assets/icons/UrgentNeeds/AcuteConditions/child_development.svg';
-import { ReactComponent as YouthDevelopment } from '../../Assets/icons/UrgentNeeds/AcuteConditions/Youth_development.svg';
-import { ReactComponent as DentalCare } from '../../Assets/icons/UrgentNeeds/AcuteConditions/dental_care.svg';
-import { ReactComponent as Food } from '../../Assets/icons/UrgentNeeds/AcuteConditions/food.svg';
-import { ReactComponent as Housing } from '../../Assets/icons/UrgentNeeds/AcuteConditions/housing.svg';
-import { ReactComponent as JobResources } from '../../Assets/icons/UrgentNeeds/AcuteConditions/job_resources.svg';
-import { ReactComponent as LegalServices } from '../../Assets/icons/UrgentNeeds/AcuteConditions/legal_services.svg';
-import { ReactComponent as Support } from '../../Assets/icons/UrgentNeeds/AcuteConditions/support.svg';
-import { ReactComponent as Military } from '../../Assets/icons/UrgentNeeds/AcuteConditions/military.svg';
-import { ReactComponent as Aging } from '../../Assets/icons/UrgentNeeds/AcuteConditions/aging.svg';
-import { ReactComponent as Resources } from '../../Assets/icons/General/resources.svg';
 import { ReactComponent as SurvivingSpouse } from '../EnergyCalculator/Icons/Person.svg';
 import { ReactComponent as Wheelchair } from '../EnergyCalculator/Icons/Wheelchair.svg';
 import { ReactComponent as HeartRate } from '../EnergyCalculator/Icons/HeartRate.svg';
 import { Language } from '../../Assets/languageOptions';
+import { Icon } from '../Icon/Icon';
+
+const OPTION_CARD_ICON_MAP: Record<string, string> = {
+  // Health Insurance
+  None: 'ban',
+  Employer: 'briefcase',
+  PrivateInsurance: 'circle-user-round',
+  Medicaid: 'heart-pulse',
+  Medicare: 'stethoscope',
+  Chp: 'baby',
+  Emergency_medicaid: 'ambulance',
+  Family_planning: 'heart-handshake',
+  VA: 'shield-plus',
+  // Conditions
+  Student: 'graduation-cap',
+  Pregnant: 'sprout',
+  BlindOrVisuallyImpaired: 'glasses',
+  Disabled: 'accessibility',
+  LongTermDisability: 'calendar-clock',
+  // Acute needs
+  Food: 'apple',
+  Baby_supplies: 'baby',
+  Housing: 'house',
+  Support: 'messages-square',
+  Child_development: 'shapes',
+  Job_resources: 'briefcase-business',
+  Dental_care: 'smile',
+  Legal_services: 'scale',
+  Savings: 'piggy-bank',
+  Military: 'shield',
+  Aging: 'circle-dot', // placeholder — mapping pending
+  Youth_development: 'circle-dot', // placeholder — mapping pending
+};
 
 
 type Item = {
@@ -46,109 +53,24 @@ type IconItem = {
   _icon: string;
 };
 
-// Transforms objects with icon key to return Icon ReactComponent
+// Transforms objects with icon key to return a Lucide Icon component.
+// EnergyCalculator-specific icons (SurvivingSpouse, Wheelchair, HeartRate) retain their
+// custom SVG components since they are outside the scope of the Lucide migration.
 function transformItemIcon(item: unknown): any {
   const icon = item as IconItem;
 
-  let iconComponent;
   switch (icon._icon) {
-    // Acute Conditions
-    case 'Baby_supplies':
-      iconComponent = <BabySupplies className={icon._classname} />;
-      break;
-    case 'Child_development':
-      iconComponent = <ChildDevelopment className={icon._classname} />;
-      break;
-    case 'Youth_development':
-      iconComponent = <YouthDevelopment className={icon._classname}  />;      
-      break;    
-    case 'Dental_care':
-      iconComponent = <DentalCare className={icon._classname} />;
-      break;
-    case 'Food':
-      iconComponent = <Food className={icon._classname} />;
-      break;
-    case 'Housing':
-      iconComponent = <Housing className={icon._classname} />;
-      break;
-    case 'Job_resources':
-      iconComponent = <JobResources className={icon._classname} />;
-      break;
-    case 'Legal_services':
-      iconComponent = <LegalServices className={icon._classname} />;
-      break;
-    case 'Support':
-      iconComponent = <Support className={icon._classname} />;
-      break;
-    case 'Military':
-      iconComponent = <Military className={icon._classname} />;
-      break;
-    case 'Aging':
-      iconComponent = <Aging className={`${icon._classname} aging`} />;
-      break;
-    case 'Savings':
-      iconComponent = <Resources className={icon._classname} />;
-      break;
-    // Conditions
-    case 'BlindOrVisuallyImpaired':
-      iconComponent = <BlindOrVisuallyImpaired className={icon._classname} />;
-      break;
-    case 'Disabled':
-      iconComponent = <Disabled className={icon._classname} />;
-      break;
-    case 'LongTermDisability':
-      iconComponent = <LongTermDisability className={icon._classname} />;
-      break;
-    case 'Pregnant':
-      iconComponent = <Pregnant className={icon._classname} />;
-      break;
-    case 'Student':
-      iconComponent = <Student className={icon._classname} />;
-      break;
-    // Health Insurance
-    case 'Chp':
-      iconComponent = <Chp className={icon._classname} />;
-      break;
-    case 'Dont_know':
-      iconComponent = <DontKnow className={icon._classname} />;
-      break;
-    case 'Emergency_medicaid':
-      iconComponent = <EmergencyMedicaid className={icon._classname} />;
-      break;
-    case 'Employer':
-      iconComponent = <Employer className={icon._classname} />;
-      break;
-    case 'Family_planning':
-      iconComponent = <FamilyPlanning className={icon._classname} />;
-      break;
-    case 'Medicaid':
-      iconComponent = <Medicaid className={icon._classname} />;
-      break;
-    case 'Medicare':
-      iconComponent = <Medicare className={icon._classname} />;
-      break;
-    case 'None':
-      iconComponent = <None className={icon._classname} />;
-      break;
-    case 'PrivateInsurance':
-      iconComponent = <PrivateInsurance className={icon._classname} />;
-      break;
     case 'SurvivingSpouse':
-      iconComponent = <SurvivingSpouse className={icon._classname} />;
-      break;
+      return <SurvivingSpouse className={icon._classname} />;
     case 'Wheelchair':
-      iconComponent = <Wheelchair className={icon._classname} />;
-      break;
+      return <Wheelchair className={icon._classname} />;
     case 'HeartRate':
-      iconComponent = <HeartRate className={icon._classname} />;
-      break;
-    // Needs a generic catch-all
-    default:
-      iconComponent = <LongTermDisability className="option-card-icon" />;
-      break;
+      return <HeartRate className={icon._classname} />;
+    default: {
+      const lucideName = OPTION_CARD_ICON_MAP[icon._icon] ?? 'circle-dot';
+      return <Icon name={lucideName} className="option-card-lucide-icon" />;
+    }
   }
-
-  return iconComponent;
 }
 
 // Recursively transform any object that has _label && _default_message as keys into a FormattedMessage

--- a/src/Components/Confirmation/Confirmation.css
+++ b/src/Components/Confirmation/Confirmation.css
@@ -49,7 +49,7 @@ svg.confirmation-lucide-icon {
 }
 
 svg.confirmation-lucide-icon * {
-  fill: white !important;
+  fill: none !important;
   stroke: var(--secondary-icon-color);
 }
 
@@ -85,6 +85,16 @@ svg.edit-button rect,
 svg.edit-button polygon {
   stroke: var(--midBlue-color);
   fill: var(--midBlue-color);
+}
+
+svg.edit-pencil-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+svg.edit-pencil-icon * {
+  stroke: var(--midBlue-color);
+  fill: none;
 }
 
 .confirmation-acute-need-list {

--- a/src/Components/Confirmation/ConfirmationBlock.tsx
+++ b/src/Components/Confirmation/ConfirmationBlock.tsx
@@ -1,4 +1,4 @@
-import { ReactComponent as Edit } from '../../Assets/icons/General/edit.svg';
+import { Pencil } from 'lucide-react';
 import { PropsWithChildren, ReactNode } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { QuestionName } from '../../Types/Questions';
@@ -43,7 +43,7 @@ export default function ConfirmationBlock({
         className="edit-button"
         aria-label={formatMessage(editAriaLabel)}
       >
-        <Edit title={formatMessage(editAriaLabel)} />
+        <Pencil aria-label={formatMessage(editAriaLabel)} className="edit-pencil-icon" />
       </Link>
     </div>
   );

--- a/src/Components/Confirmation/ConfirmationHouseholdData.tsx
+++ b/src/Components/Confirmation/ConfirmationHouseholdData.tsx
@@ -7,7 +7,7 @@ import { FormattedMessageType } from '../../Types/Questions';
 import { useConfig } from '../Config/configHook';
 import ConfirmationBlock, { formatToUSD, ConfirmationItem } from './ConfirmationBlock';
 import { Context } from '../Wrapper/Wrapper';
-import { ReactComponent as Head } from '../../Assets/icons/General/head.svg';
+import { Icon } from '../Icon/Icon';
 import { calcIncomeStreamAmount } from '../../Assets/income';
 import { useIsEnergyCalculator } from '../EnergyCalculator/hooks';
 
@@ -142,7 +142,7 @@ const DefaultConfirmationHHData = () => {
 
         return (
           <ConfirmationBlock
-            icon={<Head title={formatMessage({ id: 'confirmation.hhMember.icon-AL', defaultMessage: 'household member' })} />}
+            icon={<Icon name="user" className="confirmation-lucide-icon" aria-label={formatMessage({ id: 'confirmation.hhMember.icon-AL', defaultMessage: 'household member' })} />}
             title={relationship}
             editAriaLabel={{ id: 'confirmation.hhMember.edit-AL', defaultMessage: 'edit household member' }}
             stepName="householdData"

--- a/src/Components/Confirmation/ConfirmationSteps.tsx
+++ b/src/Components/Confirmation/ConfirmationSteps.tsx
@@ -1,13 +1,7 @@
 import { ReactNode, useContext, useMemo } from 'react';
 import { Context } from '../Wrapper/Wrapper';
 import ConfirmationBlock, { ConfirmationItem, formatToUSD } from './ConfirmationBlock';
-import { ReactComponent as Residence } from '../../Assets/icons/General/residence.svg';
-import { ReactComponent as Household } from '../../Assets/icons/General/household.svg';
-import { ReactComponent as Expense } from '../../Assets/icons/General/expenses.svg';
-import { ReactComponent as Resources } from '../../Assets/icons/General/resources.svg';
-import { ReactComponent as Benefits } from '../../Assets/icons/General/benefits.svg';
-import { ReactComponent as Immediate } from '../../Assets/icons/General/alert.svg';
-import { ReactComponent as Referral } from '../../Assets/icons/General/referral.svg';
+import { Icon } from '../Icon/Icon';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useTranslateNumber } from '../../Assets/languageOptions';
 import { FormattedMessageType, QuestionName } from '../../Types/Questions';
@@ -38,7 +32,7 @@ function ZipCode() {
 
   return (
     <ConfirmationBlock
-      icon={<Residence title={formatMessage(zipcodeIconAlt)} />}
+      icon={<Icon name="house" className="confirmation-lucide-icon" aria-label={formatMessage(zipcodeIconAlt)} />}
       title={<FormattedMessage id="confirmation.residenceInfo" defaultMessage="Residence Information" />}
       editAriaLabel={editZipAriaLabel}
       stepName="zipcode"
@@ -83,7 +77,7 @@ function HouseholdSize() {
 
   return (
     <ConfirmationBlock
-      icon={<Household title={formatMessage(householdSizeIconAlt)} />}
+      icon={<Icon name="users" className="confirmation-lucide-icon" aria-label={formatMessage(householdSizeIconAlt)} />}
       title={
         <FormattedMessage id="confirmation.displayAllFormData-yourHouseholdLabel" defaultMessage="Household Members" />
       }
@@ -152,7 +146,7 @@ function Expenses() {
 
   return (
     <ConfirmationBlock
-      icon={<Expense title={formatMessage(expensesIconAlt)} />}
+      icon={<Icon name="receipt" className="confirmation-lucide-icon" aria-label={formatMessage(expensesIconAlt)} />}
       title={
         <FormattedMessage
           id="confirmation.headOfHouseholdDataBlock-expensesLabel"
@@ -183,7 +177,7 @@ function Assets() {
 
   return (
     <ConfirmationBlock
-      icon={<Resources title={formatMessage(assetsIconAlt)} />}
+      icon={<Icon name="piggy-bank" className="confirmation-lucide-icon" aria-label={formatMessage(assetsIconAlt)} />}
       title={
         <FormattedMessage
           id="confirmation.displayAllFormData-householdResourcesText"
@@ -265,7 +259,7 @@ function HasBenefits() {
 
   return (
     <ConfirmationBlock
-      icon={<Benefits title={formatMessage(hasBenefitsIconAlt)} />}
+      icon={<Icon name="clipboard-list" className="confirmation-lucide-icon" aria-label={formatMessage(hasBenefitsIconAlt)} />}
       title={
         <FormattedMessage
           id="confirmation.displayAllFormData-currentHHBenefitsText"
@@ -316,7 +310,7 @@ function AcuteConditions() {
 
   return (
     <ConfirmationBlock
-      icon={<Immediate title={formatMessage(acuteConditionsIconAlt)} />}
+      icon={<Icon name="package-plus" className="confirmation-lucide-icon" aria-label={formatMessage(acuteConditionsIconAlt)} />}
       title={
         <FormattedMessage
           id="confirmation.displayAllFormData-acuteHHConditions"
@@ -361,7 +355,7 @@ function ReferralSource() {
 
   return (
     <ConfirmationBlock
-      icon={<Referral title={formatMessage(referralSourceIconAlt)} />}
+      icon={<Icon name="messages-square" className="confirmation-lucide-icon" aria-label={formatMessage(referralSourceIconAlt)} />}
       title={
         <FormattedMessage id="confirmation.displayAllFormData-referralSourceText" defaultMessage="Referral Source" />
       }

--- a/src/Components/CurrentBenefits/CurrentBenefits.tsx
+++ b/src/Components/CurrentBenefits/CurrentBenefits.tsx
@@ -1,6 +1,5 @@
 import { useIntl } from 'react-intl';
 import { useState, useEffect } from 'react';
-import type { ComponentType, SVGProps } from 'react';
 import { getAllLongTermPrograms, getAllNearTermPrograms } from '../../apiCalls';
 import { Translation } from '../../Types/Results';
 import ResultsTranslate from '../Results/Translate/Translate';
@@ -11,7 +10,8 @@ import { useTranslateNumber } from '../../Assets/languageOptions';
 import { useParams } from 'react-router-dom';
 import { useConfig } from '../Config/configHook';
 import { FormattedMessageType } from '../../Types/Questions';
-import { ICON_OPTIONS_MAP, LUCIDE_ICONS } from '../Results/helpers';
+import { ICON_NAME_MAP } from '../Results/helpers';
+import { Icon } from '../Icon/Icon';
 
 
 export type Program = {
@@ -139,11 +139,8 @@ const CurrentBenefits = () => {
       const { name, programs, icon } = category;
 
       const iconKey = icon.toLowerCase();
-      const actualIconKey = ICON_OPTIONS_MAP[iconKey] ? iconKey : 'default';
-      const CategoryIcon = ICON_OPTIONS_MAP[actualIconKey];
-
-      const isLucideIcon = LUCIDE_ICONS.includes(actualIconKey);
-      const iconClassName = isLucideIcon ? 'category-heading-icon category-lucide-icon' : 'category-heading-icon';
+      const lucideIconName = ICON_NAME_MAP[iconKey] ?? ICON_NAME_MAP['default'];
+      const iconClassName = 'category-heading-icon category-lucide-icon';
 
       return (
         <div key={index} className="category-section-container">
@@ -156,7 +153,7 @@ const CurrentBenefits = () => {
               })}
               role="img"
             >
-              <CategoryIcon />
+              <Icon name={lucideIconName} />
             </div>
             <h2 className="category-heading-text-style">
               <ResultsTranslate translation={name} />

--- a/src/Components/Icon/Icon.test.tsx
+++ b/src/Components/Icon/Icon.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { Icon } from './Icon';
+
+describe('Icon', () => {
+  it('renders a valid Lucide icon as an svg', () => {
+    const { container } = render(<Icon name="house" />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders nothing and warns for an unknown icon name', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { container } = render(<Icon name="not-a-real-icon-xyz" />);
+    expect(container.querySelector('svg')).toBeNull();
+    expect(warn).toHaveBeenCalledWith('Icon "not-a-real-icon-xyz" not found in Lucide icons');
+    warn.mockRestore();
+  });
+
+  it('converts kebab-case to PascalCase for lookup', () => {
+    // briefcase-business → BriefcaseBusiness (valid Lucide icon)
+    const { container } = render(<Icon name="briefcase-business" />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('forwards className to the svg element', () => {
+    const { container } = render(<Icon name="house" className="my-icon" />);
+    expect(container.querySelector('svg.my-icon')).toBeInTheDocument();
+  });
+
+  it('forwards aria-label to the svg element', () => {
+    const { container } = render(<Icon name="house" aria-label="home icon" />);
+    expect(container.querySelector('svg[aria-label="home icon"]')).toBeInTheDocument();
+  });
+
+  it('forwards size prop to the svg element', () => {
+    const { container } = render(<Icon name="house" width={48} height={48} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '48');
+    expect(svg).toHaveAttribute('height', '48');
+  });
+});

--- a/src/Components/Icon/Icon.tsx
+++ b/src/Components/Icon/Icon.tsx
@@ -1,0 +1,20 @@
+import { icons } from 'lucide-react';
+import type { LucideProps } from 'lucide-react';
+
+interface IconProps extends Omit<LucideProps, 'ref'> {
+  name: string;
+}
+
+const toPascalCase = (name: string) =>
+  name.split('-').map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join('');
+
+export function Icon({ name, ...props }: IconProps) {
+  const LucideIcon = icons[toPascalCase(name) as keyof typeof icons];
+
+  if (!LucideIcon) {
+    console.warn(`Icon "${name}" not found in Lucide icons`);
+    return null;
+  }
+
+  return <LucideIcon {...props} />;
+}

--- a/src/Components/Icon/iconMaps.test.tsx
+++ b/src/Components/Icon/iconMaps.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Guards the icon-name maps against typos: every value in OPTION_CARD_ICON_MAP and
+ * ICON_NAME_MAP must resolve to a real Lucide icon. A bad name renders nothing and
+ * only console.warns at runtime (see Icon.tsx), so this catches it at test time.
+ * This is the same class of bug that the `house-roof` correction fixed during development.
+ */
+import { render } from '@testing-library/react';
+import { Icon } from './Icon';
+import { ICON_NAME_MAP } from '../Results/helpers';
+import { OPTION_CARD_ICON_MAP } from '../Config/configHook';
+
+type Entry = [map: string, key: string, name: string];
+
+const entriesFor = (map: string, record: Record<string, string>): Entry[] =>
+  Object.entries(record).map(([key, name]) => [map, key, name]);
+
+const cases: Entry[] = [
+  ...entriesFor('OPTION_CARD_ICON_MAP', OPTION_CARD_ICON_MAP),
+  ...entriesFor('ICON_NAME_MAP', ICON_NAME_MAP),
+];
+
+describe('icon name maps resolve to real Lucide icons', () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it.each(cases)('%s["%s"] = "%s" renders a Lucide svg', (_map, _key, name) => {
+    const { container } = render(<Icon name={name} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('maps the Aging and Youth_development option cards to non-placeholder icons', () => {
+    expect(OPTION_CARD_ICON_MAP['Aging']).toBe('tree-deciduous');
+    expect(OPTION_CARD_ICON_MAP['Youth_development']).toBe('shapes');
+  });
+
+  it('keeps the results-side aging/youth_development icons in sync with the option cards', () => {
+    expect(ICON_NAME_MAP['aging']).toBe('tree-deciduous');
+    expect(ICON_NAME_MAP['youth_development']).toBe('shapes');
+  });
+});

--- a/src/Components/Results/CategoryHeading/CategoryHeading.tsx
+++ b/src/Components/Results/CategoryHeading/CategoryHeading.tsx
@@ -5,7 +5,8 @@ import { useTranslateNumber } from '../../../Assets/languageOptions';
 import { ProgramCategory } from '../../../Types/Results';
 import { useContext } from 'react';
 import { Context } from '../../Wrapper/Wrapper';
-import { LUCIDE_ICONS, ICON_OPTIONS_MAP } from '../helpers';
+import { ICON_NAME_MAP } from '../helpers';
+import { Icon } from '../../Icon/Icon';
 
 type CategoryHeadingProps = {
   category: ProgramCategory;
@@ -18,8 +19,7 @@ const CategoryHeading = ({ category, showAmount }: CategoryHeadingProps) => {
   const translateNumber = useTranslateNumber();
 
   const iconKey = category.icon.toLowerCase();
-  const actualIconKey = ICON_OPTIONS_MAP[iconKey] ? iconKey : 'default';  
-  const IconComponent = ICON_OPTIONS_MAP[actualIconKey];
+  const lucideIconName = ICON_NAME_MAP[iconKey] ?? ICON_NAME_MAP['default'];
 
   const monthlyCategoryAmt = calculateTotalValue(category) / 12;
   const shouldShowAmount = showAmount ?? !getReferrer('uiOptions').includes('dont_show_category_values');
@@ -30,19 +30,16 @@ const CategoryHeading = ({ category, showAmount }: CategoryHeadingProps) => {
   };
   const iconTranslation = intl.formatMessage({ id: 'categoryHeading.icon', defaultMessage: 'icon' });
 
-  // Add lucide icon class for specific icons that need white fill
-  const iconClasses = `category-heading-icon${LUCIDE_ICONS.includes(actualIconKey) ? ' category-lucide-icon' : ''}`;
-
   return (
     <div>
       <div className="category-heading-container">
         <div className="category-heading-column">
           <div
-            className={iconClasses}
+            className="category-heading-icon category-lucide-icon"
             aria-label={`${intl.formatMessage(categoryImageAriaLabelProps)} ${iconTranslation}`}
             role="img"
           >
-            <IconComponent aria-hidden="true" />
+            <Icon name={lucideIconName} aria-hidden={true} />
           </div>
           <h2 className="category-heading-text-style">
             <ResultsTranslate translation={category.name} />

--- a/src/Components/Results/Needs/NeedCard.css
+++ b/src/Components/Results/Needs/NeedCard.css
@@ -11,12 +11,16 @@
   font-weight: 400;
 }
 
-.result-resource-more-info svg,
-.result-resource-more-info svg path.cls-1 {
-  fill: var(--icon-color);
-  margin-right: 0.25rem;
-  height: 4.5rem;
-  width: 4.5rem;
+.result-resource-more-info svg {
+  margin-left: 0.75rem;
+  margin-right: 0.75rem;
+  height: 3rem;
+  width: 3rem;
+}
+
+svg.need-card-lucide-icon * {
+  fill: none !important;
+  stroke: var(--icon-color) !important;
 }
 
 .result-resource-more-info span {

--- a/src/Components/Results/Needs/NeedCard.tsx
+++ b/src/Components/Results/Needs/NeedCard.tsx
@@ -3,7 +3,8 @@ import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { UrgentNeed } from '../../../Types/Results';
 import ResultsTranslate from '../Translate/Translate';
-import { formatPhoneNumber, generateNeedId, ICON_OPTIONS_MAP } from '../helpers';
+import { formatPhoneNumber, generateNeedId, ICON_NAME_MAP } from '../helpers';
+import { Icon } from '../../Icon/Icon';
 import TrackedOutboundLink from '../../Common/TrackedOutboundLink/TrackedOutboundLink';
 import './NeedCard.css';
 
@@ -12,13 +13,8 @@ type NeedsCardProps = {
 };
 
 const getIcon = (messageType: string) => {
-  const Icon = ICON_OPTIONS_MAP[messageType] ?? ICON_OPTIONS_MAP['default'];
-
-  if (Icon !== undefined) {
-    return <Icon />;
-  }
-
-  return null;
+  const lucideIconName = ICON_NAME_MAP[messageType] ?? ICON_NAME_MAP['default'];
+  return <Icon name={lucideIconName} className="need-card-lucide-icon" />;
 };
 
 const NeedCard = ({ need }: NeedsCardProps) => {

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -12,7 +12,8 @@ import { findProgramById, findValidationForProgram, useResultsContext, useResult
 import { deleteValidation, postValidation } from '../../../apiCalls';
 import { Language } from '../../../Assets/languageOptions';
 import { allNavigatorLanguages } from './NavigatorLanguages';
-import { formatPhoneNumber, LUCIDE_ICONS, ICON_OPTIONS_MAP } from '../helpers';
+import { formatPhoneNumber, ICON_NAME_MAP } from '../helpers';
+import { Icon } from '../../Icon/Icon';
 import useScreenApi from '../../../Assets/updateScreen';
 import { Box, Button, ButtonGroup, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from '@mui/material';
 import JsonView from '@uiw/react-json-view';
@@ -55,13 +56,8 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
   };
 
   const IconRenderer: React.FC<IconRendererProps> = ({ headingType }) => {
-    const IconComponent = ICON_OPTIONS_MAP[headingType] ?? ICON_OPTIONS_MAP['default'];
-
-    if (!IconComponent) {
-      return null;
-    }
-
-    return <IconComponent />;
+    const lucideIconName = ICON_NAME_MAP[headingType] ?? ICON_NAME_MAP['default'];
+    return <Icon name={lucideIconName} />;
   };
   const currentValidation = findValidationForProgram(validations, program);
 
@@ -136,8 +132,7 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
   const displayIconAndHeader = (program: Program) => {
     // Add lucide icon class for specific icons that need white fill
     const iconKey = category.icon.toLowerCase();
-    const actualIconKey = ICON_OPTIONS_MAP[iconKey] ? iconKey : 'default';
-    const iconClasses = `header-icon-box${LUCIDE_ICONS.includes(actualIconKey) ? ' header-icon-lucide' : ''}`;
+    const iconClasses = 'header-icon-box header-icon-lucide';
 
     return (
       <header className="program-icon-and-header">

--- a/src/Components/Results/helpers.ts
+++ b/src/Components/Results/helpers.ts
@@ -6,7 +6,7 @@ import { parsePhoneNumberFromString } from 'libphonenumber-js';
  * Keys must be lower case. Values are kebab-case Lucide icon names.
  */
 export const ICON_NAME_MAP: Record<string, string> = {
-  aging: 'circle-dot', // placeholder — mapping pending
+  aging: 'tree-deciduous',
   baby_supplies: 'baby',
   behavioral_health: 'message-circle-heart',
   cash: 'circle-dollar-sign',
@@ -32,6 +32,7 @@ export const ICON_NAME_MAP: Record<string, string> = {
   transportation: 'bus-front',
   triangle_alert: 'triangle-alert',
   veteran_services: 'shield',
+  youth_development: 'shapes',
   default: 'circle-dot',
 };
 

--- a/src/Components/Results/helpers.ts
+++ b/src/Components/Results/helpers.ts
@@ -1,70 +1,38 @@
-import type { ComponentType, SVGProps } from 'react';
 import { parsePhoneNumberFromString } from 'libphonenumber-js';
-import { ReactComponent as Food } from '../../Assets/icons/UrgentNeeds/AcuteConditions/food.svg';
-import { ReactComponent as Residence } from '../../Assets/icons/General/residence.svg';
-import { ReactComponent as HealthCare } from '../../Assets/icons/Programs/CategoryHeading/healthcare.svg';
-import { ReactComponent as Transportation } from '../../Assets/icons/Programs/CategoryHeading/transportation.svg';
-import { ReactComponent as TaxCredits } from '../../Assets/icons/Programs/CategoryHeading/taxCredits.svg';
-import { ReactComponent as CashAssistance } from '../../Assets/icons/Programs/CategoryHeading/cashAssistant.svg';
-import { ReactComponent as ChildCareYouthEducation } from '../../Assets/icons/Programs/CategoryHeading/childCareYouthEducation.svg';
-import { ReactComponent as Coin } from '../EnergyCalculator/Icons/Coin.svg';
-import { ReactComponent as LightBulb } from '../EnergyCalculator/Icons/Lightbulb.svg';
-import { ReactComponent as Talk } from '../EnergyCalculator/Icons/Messages.svg';
-import { ReactComponent as TriangleAlert } from '../EnergyCalculator/Icons/TriangleAlert.svg';
-import { ReactComponent as Lightning } from '../EnergyCalculator/Icons/Lightning.svg';
-import { ReactComponent as HeartHand } from '../EnergyCalculator/Icons/HeartHand.svg';
-import { ReactComponent as BabySupplies } from '../../Assets/icons/UrgentNeeds/AcuteConditions/baby_supplies.svg';
-import { ReactComponent as ChildDevelopment } from '../../Assets/icons/UrgentNeeds/AcuteConditions/child_development.svg';
-import { ReactComponent as DentalCare } from '../../Assets/icons/UrgentNeeds/AcuteConditions/dental_care.svg';
-import { ReactComponent as FamilyPlanning } from '../../Assets/icons/UrgentNeeds/AcuteConditions/family_planning.svg';
-import { ReactComponent as Housing } from '../../Assets/icons/UrgentNeeds/AcuteConditions/housing.svg';
-import { ReactComponent as JobResources } from '../../Assets/icons/UrgentNeeds/AcuteConditions/job_resources.svg';
-import { ReactComponent as LegalServices } from '../../Assets/icons/UrgentNeeds/AcuteConditions/legal_services.svg';
-import { ReactComponent as Support } from '../../Assets/icons/UrgentNeeds/AcuteConditions/support.svg';
-import { ReactComponent as Military } from '../../Assets/icons/UrgentNeeds/AcuteConditions/military.svg';
-import { ReactComponent as Aging } from '../../Assets/icons/UrgentNeeds/AcuteConditions/aging.svg';
-import { ReactComponent as Disabled } from '../../Assets/icons/General/OptionCard/Conditions/disabled.svg';
-import { ReactComponent as Resources } from '../../Assets/icons/General/resources.svg';
 
 /**
- * List of lucide-based icon names that require special styling (white fill with colored stroke)
- * Used across CategoryHeading and ProgramPage components
+ * Mapping of icon keys (from API/backend) to their corresponding Lucide icon names.
+ * Used across CategoryHeading, ProgramPage, CurrentBenefits, and NeedCard components.
+ * Keys must be lower case. Values are kebab-case Lucide icon names.
  */
-export const LUCIDE_ICONS = ['house_plug', 'light_bulb', 'talk', 'air_vent', 'coin', 'heart_hand', 'lightning', 'triangle_alert'];
-
-/**
- * Mapping of icon keys (from API/backend) to their corresponding React SVG components
- * Used across CategoryHeading, ProgramPage, and CurrentBenefits components
- * NOTE: keys must be lower case
- */
-export const ICON_OPTIONS_MAP: Record<string, ComponentType<SVGProps<SVGSVGElement>>> = {
-  aging: Aging,
-  baby_supplies: BabySupplies,
-  behavioral_health: Support,
-  cash: CashAssistance,
-  coin: Coin,
-  child_care: ChildCareYouthEducation,
-  child_development: ChildDevelopment,
-  dental_care: DentalCare,
-  disability: Disabled,
-  family_planning: FamilyPlanning,
-  food: Food,
-  food_groceries: Food,
-  health_care: HealthCare,
-  heart_hand: HeartHand,
-  housing: Residence,
-  job_resources: JobResources,
-  legal_services: LegalServices,
-  light_bulb: LightBulb,
-  lightning: Lightning,
-  managing_housing: Housing,
-  savings: Resources,
-  talk: Talk,
-  tax_credit: TaxCredits,
-  transportation: Transportation,
-  triangle_alert: TriangleAlert,
-  veteran_services: Military,
-  default: CashAssistance,
+export const ICON_NAME_MAP: Record<string, string> = {
+  aging: 'circle-dot', // placeholder — mapping pending
+  baby_supplies: 'baby',
+  behavioral_health: 'message-circle-heart',
+  cash: 'circle-dollar-sign',
+  child_care: 'blocks',
+  child_development: 'shapes',
+  coin: 'coins',
+  dental_care: 'smile',
+  disability: 'accessibility',
+  family_planning: 'heart-handshake',
+  food: 'apple',
+  food_groceries: 'apple',
+  health_care: 'square-activity',
+  heart_hand: 'heart-handshake',
+  housing: 'house',
+  job_resources: 'briefcase-business',
+  legal_services: 'scale',
+  light_bulb: 'lightbulb',
+  lightning: 'zap',
+  managing_housing: 'house',
+  savings: 'piggy-bank',
+  talk: 'message-circle',
+  tax_credit: 'banknote',
+  transportation: 'bus-front',
+  triangle_alert: 'triangle-alert',
+  veteran_services: 'shield',
+  default: 'circle-dot',
 };
 
 export const formatPhoneNumber = (phoneNumber: string): string => {

--- a/src/Components/SelectTiles/MultiSelectTiles.tsx
+++ b/src/Components/SelectTiles/MultiSelectTiles.tsx
@@ -1,12 +1,14 @@
 import { Card, CardActionArea } from '@mui/material';
 import { ReactNode, useCallback } from 'react';
 import { FormattedMessageType } from '../../Types/Questions';
+import { Icon } from '../Icon/Icon';
 import './SelectTiles.css';
 
 export type MultiSelectTileOption<T extends string | number> = {
   value: T;
   text: FormattedMessageType;
-  icon: ReactNode;
+  /** Lucide icon name (kebab-case) or a ReactNode for legacy/EnergyCalculator icons */
+  icon: string | ReactNode;
 };
 
 type TileProps<T extends string | number> = {
@@ -29,7 +31,13 @@ function Tile<T extends string | number>({ option, selected, onClick, variant }:
     <CardActionArea className="card-action-area" onClick={onClick} aria-pressed={selected}>
       <Card className={containerClass}>
         <div className="option-card-content">
-          <div className="option-card-icon">{option.icon}</div>
+          <div className="option-card-icon">
+            {typeof option.icon === 'string' ? (
+              <Icon name={option.icon} className="option-card-lucide-icon" />
+            ) : (
+              option.icon
+            )}
+          </div>
           <span className={['option-card-label', selected && 'option-card-selected-text'].filter(Boolean).join(' ')}>
             {option.text}
           </span>

--- a/src/Components/SelectTiles/SelectTiles.css
+++ b/src/Components/SelectTiles/SelectTiles.css
@@ -146,7 +146,7 @@
 }
 
 .option-card-lucide-icon * {
-  fill: white !important;
+  fill: none !important;
   stroke: var(--icon-color) !important;
 }
 
@@ -185,7 +185,7 @@
 }
 
 .option-card--selected .option-card-lucide-icon * {
-  fill: var(--primary-color) !important;
+  fill: none !important;
   stroke: white !important;
 }
 

--- a/src/hooks/useFormOptions.test.tsx
+++ b/src/hooks/useFormOptions.test.tsx
@@ -1,0 +1,89 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useFormOptions, FormOptionsResponse } from './useFormOptions';
+
+const sampleResponse: FormOptionsResponse = {
+  condition_options: [{ value: 'housing', icon: 'house', text: { label: 'test.housing', default_message: 'Housing' } }],
+  health_insurance_options: [],
+};
+
+// Mock fetch globally
+global.fetch = jest.fn();
+
+describe('useFormOptions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not fetch and resolves loading to false when whiteLabel is empty', async () => {
+    const { result } = renderHook(() => useFormOptions(''));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.formOptions).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns form options and clears loading on a successful fetch', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(sampleResponse),
+    });
+
+    const { result } = renderHook(() => useFormOptions('co'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(result.current.formOptions).toEqual(sampleResponse);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error and clears loading on a non-ok response', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    });
+
+    const { result } = renderHook(() => useFormOptions('co'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.formOptions).toBeNull();
+  });
+
+  it('aborts the in-flight request on unmount', () => {
+    const abortSpy = jest.spyOn(AbortController.prototype, 'abort');
+    // Never-resolving fetch so the success/error handlers do not run post-unmount.
+    (global.fetch as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+    const { unmount } = renderHook(() => useFormOptions('co'));
+    unmount();
+
+    expect(abortSpy).toHaveBeenCalled();
+    abortSpy.mockRestore();
+  });
+
+  it('swallows AbortError without setting error state', async () => {
+    const abortError = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    (global.fetch as jest.Mock).mockRejectedValueOnce(abortError);
+
+    const { result } = renderHook(() => useFormOptions('co'));
+
+    // Let the rejected fetch flush through the catch handler.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.formOptions).toBeNull();
+  });
+});

--- a/src/hooks/useFormOptions.ts
+++ b/src/hooks/useFormOptions.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react';
+
+export interface FormOptionText {
+  label: string;
+  default_message: string;
+}
+
+export interface FormOption {
+  value: string;
+  icon: string | null;
+  text: FormOptionText;
+}
+
+export interface FormOptionsResponse {
+  condition_options: FormOption[];
+  health_insurance_options: FormOption[];
+}
+
+const domain = process.env.REACT_APP_DOMAIN_URL;
+
+export function useFormOptions(whiteLabel: string) {
+  const [formOptions, setFormOptions] = useState<FormOptionsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!whiteLabel) return;
+
+    const apiKey = 'Token ' + process.env.REACT_APP_API_KEY;
+
+    fetch(`${domain}/api/${whiteLabel}/form-options/`, {
+      headers: {
+        Accept: 'application/json',
+        Authorization: apiKey,
+      },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to fetch form options: ${res.status}`);
+        return res.json() as Promise<FormOptionsResponse>;
+      })
+      .then((data) => {
+        setFormOptions(data);
+        setLoading(false);
+      })
+      .catch((err: Error) => {
+        setError(err);
+        setLoading(false);
+      });
+  }, [whiteLabel]);
+
+  return { formOptions, loading, error };
+}

--- a/src/hooks/useFormOptions.ts
+++ b/src/hooks/useFormOptions.ts
@@ -24,15 +24,22 @@ export function useFormOptions(whiteLabel: string) {
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    if (!whiteLabel) return;
+    if (!whiteLabel) {
+      setLoading(false);
+      return;
+    }
 
     const apiKey = 'Token ' + process.env.REACT_APP_API_KEY;
+    const controller = new AbortController();
+
+    setLoading(true);
 
     fetch(`${domain}/api/${whiteLabel}/form-options/`, {
       headers: {
         Accept: 'application/json',
         Authorization: apiKey,
       },
+      signal: controller.signal,
     })
       .then((res) => {
         if (!res.ok) throw new Error(`Failed to fetch form options: ${res.status}`);
@@ -43,9 +50,13 @@ export function useFormOptions(whiteLabel: string) {
         setLoading(false);
       })
       .catch((err: Error) => {
+        // Ignore aborts from a superseded white label / unmount.
+        if (err.name === 'AbortError') return;
         setError(err);
         setLoading(false);
       });
+
+    return () => controller.abort();
   }, [whiteLabel]);
 
   return { formOptions, loading, error };


### PR DESCRIPTION
## Context & Motivation

- Fixes MFB-396
- Migrates the custom SVG icon library to [Lucide React](https://lucide.dev/) across the entire frontend. The previous approach used hand-crafted SVG files imported as React components, making it difficult to add, update, or swap icons. Lucide provides a large, consistent open-source icon set with a single installation.

## Changes Made

**New component**
- `src/Components/Icon/Icon.tsx` — generic Lucide icon wrapper; accepts a kebab-case `name` prop, converts to PascalCase via a helper, and resolves the icon from the `lucide-react` `icons` map. Returns `null` with a `console.warn` if the name is not found.

**New hook**
- `src/hooks/useFormOptions.ts` — fetches `GET /api/<wl>/form-options/` and returns `{ formOptions, loading, error }` with fully typed `FormOptionsResponse`. Ready to wire into step components when the backend data migration (Phase 2) populates the endpoint. Sets `loading` to `false` (rather than hanging) when no white label is supplied, and uses an `AbortController` to cancel the in-flight request on white-label change/unmount (avoiding stale-response races and setState-after-unmount). Covered by `src/hooks/useFormOptions.test.tsx`.

**Icon name maps (replacing SVG imports)**
- `src/Components/Results/helpers.ts` — removed all SVG imports and the `ICON_OPTIONS_MAP` / `LUCIDE_ICONS` exports; added `ICON_NAME_MAP: Record<string, string>` mapping category/need keys to kebab-case Lucide names. `aging` → `tree-deciduous` and a new `youth_development` → `shapes` entry (previously placeholders / unmapped).
- `src/Components/Config/configHook.tsx` — removed ~30 SVG imports (EnergyCalculator icons `SurvivingSpouse`, `Wheelchair`, `HeartRate` retained as custom SVGs); added `OPTION_CARD_ICON_MAP: Record<string, string>` (exported) for health-insurance, condition, and acute-need option cards; replaced the full switch statement with a map lookup + `<Icon>`. `Aging` → `tree-deciduous` and `Youth_development` → `shapes` (previously `circle-dot` placeholders).

**Component updates (using `<Icon>` instead of custom SVGs)**
- `CategoryHeading.tsx` — Lucide `<Icon>` with `category-lucide-icon` class
- `NeedCard.tsx` — Lucide `<Icon>` with `need-card-lucide-icon` class
- `ProgramPage.tsx` — Lucide `<Icon>` with `header-icon-lucide` class
- `CurrentBenefits.tsx` — Lucide `<Icon>` with `category-lucide-icon` class
- `ConfirmationSteps.tsx` — replaced 7 SVG imports with `<Icon>` using `confirmation-lucide-icon` class; icon assignments: `house`, `users`, `receipt`, `piggy-bank`, `clipboard-list`, `package-plus`, `messages-square`
- `ConfirmationHouseholdData.tsx` — replaced `<Head>` SVG with `<Icon name="user">`
- `ConfirmationBlock.tsx` — replaced `<Edit>` SVG with `<Pencil>` from `lucide-react` directly, using new `edit-pencil-icon` class (1.25rem, `--midBlue-color`)

**`MultiSelectTiles` type update**
- `icon` field changed from `ReactNode` to `string | ReactNode`
- When a `string` is passed, `Tile` renders `<Icon name={...} className="option-card-lucide-icon" />` automatically
- Existing EnergyCalculator callers passing `ReactNode` icons continue working unchanged
- Step components consuming `useFormOptions` (Phase 2) can pass Lucide name strings directly

**CSS fixes — fill/stroke inheritance bug**

Lucide icons render as stroke-only by default (`fill="none"` on the SVG root). Several existing CSS rules set `fill: <color>` on the SVG element or on `*` children, causing two categories of breakage:

1. **Inherited fill** — `fill` set on the `<svg>` element is an inherited SVG property. Child paths without their own fill declaration inherit the color, turning the whole icon into a solid blob.
2. **Covered inner details** — `fill: <color>` on `*` paints closed outer paths (e.g. outer circle of `circle-user-round`, face outline of `baby`) over interior paths that form details like eyes and head silhouettes.

Fix applied consistently across all icon contexts: `fill: none !important` on `*` children.

| File | Rule changed |
|---|---|
| `SelectTiles.css` | `.option-card-lucide-icon *` — `fill: white` → `fill: none` |
| `SelectTiles.css` | `.option-card--selected .option-card-lucide-icon *` — `fill: var(--primary-color)` → `fill: none` |
| `Confirmation.css` | `svg.confirmation-lucide-icon *` — `fill: white` → `fill: none` |
| `Confirmation.css` | New `svg.edit-pencil-icon` rule — `1.25rem`, `stroke: var(--midBlue-color)`, `fill: none` |
| `NeedCard.css` | Removed `fill: var(--icon-color)` from `.result-resource-more-info svg`; added `svg.need-card-lucide-icon *` with `fill: none !important; stroke: var(--icon-color) !important`; icon size 4.5rem → 3rem |

**Icon name corrections discovered during testing**
- `house-roof` does not exist in `lucide-react` 1.22.0 (latest); replaced with `house`
- `messages-square` (with `s`) is correct for two-speech-bubbles; `message-square` is a single bubble

## Testing

- Migrations to run: none (frontend only)
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  1. `npm install` in `benefits-calculator/` to ensure `lucide-react` is present
  2. Start dev server (`npm start`)
  3. Walk through the screener end-to-end and verify icons render at each step
  4. Health insurance step — select/deselect tiles; icons visible in both selected (white stroke on dark) and unselected (orange stroke on white) states
  5. Conditions step — verify `Pregnant` (sprout), `Blind or Visually Impaired` (glasses), `Long-term Disability` (calendar-clock)
  6. Acute needs step — all 10 tiles have icons; `Housing` shows the house icon
  7. Confirmation page — all section icons render; pencil edit icon is small and blue
  8. `/near-term-needs` — icons are orange stroke-only (no filled blobs), ~3rem, with left margin
  9. Run `npm test -- --testPathPattern="Icon/Icon"` — 6 tests should pass
  10. Run `npm test -- --testPathPattern="useFormOptions"` — 5 tests should pass
  11. Run `npm test -- --testPathPattern="iconMaps"` — 56 tests should pass (every icon-map value resolves to a real Lucide icon)

## Deployment

- Post-deployment scripts needed: none
- Production config updates: none
- Admin updates needed: none
- Notify team/users of: visual change to icons site-wide across all white labels

## Notes for Reviewers

- Known limitations:
  - EnergyCalculator-specific icons (`SurvivingSpouse`, `Wheelchair`, `HeartRate`) are intentionally kept as custom SVGs — out of scope for this migration
  - `house-roof` is not in the main `lucide-react` package; may exist in `@lucide/lab` (experimental). Using `house` to avoid a dependency for a single icon.
  - `MultiSelectTiles.icon` is `string | ReactNode` rather than a pure `string` because EnergyCalculator steps pass custom SVG components — these will be migrated separately
- Future considerations (Phase 2):
  - Wire `useFormOptions` into `ImmediateNeeds`, `HealthInsuranceSection`, `SpecialConditionsSection` to replace hardcoded `OPTION_CARD_ICON_MAP` / `ICON_NAME_MAP`
  - Delete unused SVG assets from `src/Assets/icons/` once Phase 2 is confirmed on staging

## Post-Review Updates (code review follow-up)

Hardened the new `useFormOptions` hook in response to review findings (the hook is not yet wired in, so no user-facing behavior changes — this is to prevent foot-guns when it's consumed in Phase 2):

- **Loading no longer hangs on an empty white label.** The `!whiteLabel` early-return now sets `loading` to `false` instead of leaving the initial `true` in place forever.
- **Added request cancellation.** An `AbortController` aborts the in-flight `fetch` on white-label change/unmount, and `AbortError` is swallowed — eliminating the stale-response race and setState-after-unmount warning.
- **Added test coverage.** New `src/hooks/useFormOptions.test.tsx` (5 tests): no fetch + `loading=false` on empty white label, successful fetch, non-ok response error path, abort-on-unmount, and AbortError-swallow.


### Icon-map finalization + guard test

- **Assigned real icons to `Aging` and `Youth_development`** in both maps, replacing the `circle-dot` placeholders: `tree-deciduous` (Aging) and `shapes` (Youth_development). `ICON_NAME_MAP` previously had no `youth_development` key at all — it was added so the results/category side stays in sync with the option cards.
- **Added `src/Components/Icon/iconMaps.test.tsx` (56 cases).** Renders every value in `OPTION_CARD_ICON_MAP` and `ICON_NAME_MAP` through the `<Icon>` component and asserts each produces an `<svg>` with no `console.warn` — a typo'd Lucide name renders nothing and only warns at runtime, so this catches it at test time (the bug class behind the `house-roof` correction). Includes explicit assertions pinning the `aging`/`youth_development` mappings across both maps. `OPTION_CARD_ICON_MAP` was exported (previously module-private) to enable this.
- Note: the mixed casing of `OPTION_CARD_ICON_MAP` keys (e.g. `Medicaid`, `Baby_supplies`) is intentional — they must match the `_icon` string values emitted by the backend white-label configs verbatim. Normalizing them is deferred to Phase 2 when these values move into `FormOption.value`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new form options hook to load configuration from the server with loading and error handling.
  * Introduced broader icon support across the app, including more consistent icon rendering in tiles, results, confirmation, and category headings.

* **Bug Fixes**
  * Improved icon display consistency and sizing across multiple screens.
  * Added safer handling for unknown icons and request cancellation to avoid broken states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->