### PR TITLE
MFB-1235: Fix Navigator language display to both wrap and exclude empty language boxes

### DIFF
--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -273,6 +273,7 @@ li.apply-info {
 
 .navigator-langs-container {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
   margin: 0.25rem 0;
 }

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -200,9 +200,17 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
 
   const backLink = useResultsLink(`results/benefits`);
   const displayLanguageFlags = (navigatorLanguages: Language[]) => {
+    // Only render flags for languages we have a label for; unknown codes
+    // (e.g. "uk", "ja", "de") would otherwise render as empty boxes.
+    const knownLanguages = navigatorLanguages.filter((lang) => allNavigatorLanguages[lang] !== undefined);
+
+    if (knownLanguages.length === 0) {
+      return null;
+    }
+
     return (
       <div className="navigator-langs-container">
-        {navigatorLanguages.map((lang) => {
+        {knownLanguages.map((lang) => {
           return (
             <p className="navigator-lang-flag" key={lang}>
               {allNavigatorLanguages[lang]}


### PR DESCRIPTION
## Context & Motivation

Navigator language flags on the Program page had two display bugs (MFB-1235):

1. **Overflow** — navigators with many languages (e.g. WA Healthplanfinder Customer Support Center has 15) overflowed the bounded "Get Help Applying" box instead of wrapping.
2. **Empty boxes** — the API returns language codes not present in the frontend's `allNavigatorLanguages` map (e.g. `uk`, `ja`, `lo`, `km`, `pa`, `de`). Each unknown code rendered as an empty green flag box.

- Fixes MFB-1235

## Changes Made

- `ProgramPage.css` — added `flex-wrap: wrap` to `.navigator-langs-container` so flags wrap within the box.
- `ProgramPage.tsx` — `displayLanguageFlags` now filters to only language codes that have a label in `allNavigatorLanguages`, and returns `null` (rendering no container) when none remain, eliminating empty flag boxes.

## Testing

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:
  1. Open a WA program page with a navigator that has many languages, e.g. `/wa/<uuid>/results/benefits/<program>` (staging repro: navigator id 1478, WA Healthplanfinder Customer Support Center).
  2. Confirm the language flags wrap within the "Get Help Applying" box instead of overflowing horizontally.
  3. Confirm no empty/blank green flag boxes appear for unsupported language codes (`uk`, `ja`, `lo`, `km`, `pa`, `de`).

## Deployment

- Post-deployment scripts needed: None
- Production config updates: None
- Admin updates needed: None
- Notify team/users of: N/A

### Cleanup task (separate from this FE fix — run in benefits-api on each env)

The `navLanguage.tl` translation renders as **"Tagalong Available"** (typo) instead of "Tagalog Available". This is a data issue in the `Translation` table (django-parler `translations_translation_translation`), not in code — the frontend `defaultMessage` is already correct. It is **not** re-seeded by migrations, so a manual fix is durable; the only thing that could re-introduce it is re-running `add_translations`/`bulk_add_translations` with a JSON map that still contains the misspelling.

Fix on **local, staging, and prod** by re-running the canonical translation path (overwrites `en-us` and re-auto-translates all languages correctly, handling history + cache invalidation):

```bash
# preview first
echo '{"navLanguage.tl": "Tagalog Available"}' | python manage.py add_translations --dry-run

# then apply (no --dry-run) on each env
echo '{"navLanguage.tl": "Tagalog Available"}' | python manage.py add_translations
```

- No `{placeholder}` tokens in this string, so it's not exposed to the auto-translate placeholder-mangling issue.
- Verify afterward that the non-English rows for `navLanguage.tl` were re-translated from the corrected English.

## Notes for Reviewers

- Known limitations: The `languages` field is typed `Language[]` (an 18-code union), but the backend sends codes outside that union. This PR handles them defensively at render time by hiding them. Actually *displaying* flags for codes like Ukrainian/Japanese/German would require extending both the `Language` type and the `allNavigatorLanguages` map — out of scope here, worth a follow-up ticket if those languages should surface.
- Future considerations: Consider aligning the backend navigator language set with the frontend-supported languages, or extending the frontend map to cover all codes the backend can emit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language flag display on program pages so only recognized languages are shown.
  * Prevented empty flag placeholders from appearing for unknown language codes.
  * Updated the language flag area to wrap onto multiple lines when needed for better layout on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->