### PR TITLE
MFB-1256: Fix inconsistent header row spacing on Program Details view

### DIFF
--- a/src/Components/Results/ProgramPage/ProgramPage.css
+++ b/src/Components/Results/ProgramPage/ProgramPage.css
@@ -9,7 +9,7 @@
 .program-icon-and-header {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   width: 100%;
 }
 
@@ -228,7 +228,11 @@ li.apply-info {
 
 .icon-header-est-values {
   display: flex;
-  justify-content: space-evenly;
+  justify-content: space-between;
+  /* Span the full card width. Without this, the parent (a centered flex column)
+     shrinks this row to its content width and centers it, so the icon/title/
+     estimation spacing drifts based on program name and value length. */
+  width: 100%;
 }
 
 .content-width {


### PR DESCRIPTION
## Context & Motivation

The header row on the Program Details view (icon · category/title · orange estimation box) rendered with inconsistent spacing across programs. On programs with short names and small values (e.g. Head Start / Child Care) the whole row collapsed toward the center — the icon was indented from the left and the orange box was pulled in from the right — while programs with longer content (e.g. KanCare (Medicaid)) filled the row correctly.

Originally suspected to be a side effect of the recent Lucide icon work (MFB-396 #2140 / MFB-1245 #2142), but that was ruled out: those PRs only changed the Program **Results** page (`CategoryHeading` / `Results.css`), and the details page has no per-icon CSS — `blocks` (Child Care) and every other icon flow through identical rules. The real cause was that `.icon-header-est-values` had no `width` inside a centered flex column, so the row shrank to its content width and centered itself, making spacing depend on program name / value length.

- Fixes MFB-1256

## Changes Made

`src/Components/Results/ProgramPage/ProgramPage.css` (desktop only — the mobile `@media (max-width: 767px)` block already overrides both rules and is unaffected):

- `.icon-header-est-values`: added `width: 100%` so the row always spans the full card width (matching the content below it), and switched `justify-content: space-evenly` → `space-between`.
- `.program-icon-and-header`: `justify-content: flex-end` → `flex-start`, so the icon is reliably anchored at the left instead of drifting right when the title happens not to fill the row.

Result: the icon/title/estimation split is now consistent regardless of program name or value length — icon pinned left, orange box pinned right.

## Testing

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:
  - Open a program with a short name / small value (e.g. Head Start) and a program with a longer name / larger value (e.g. KanCare (Medicaid)) on the Program Details view.
  - Confirm both align identically: icon pinned to the left edge, orange estimation box pinned to the right edge, with consistent spacing between.
  - Verify both desktop and mobile (≤767px) layouts render correctly.

## Deployment

- Post-deployment scripts needed: None
- Production config updates: None
- Admin updates needed: None
- Notify team/users of: N/A

## Notes for Reviewers

- Known limitations: CSS-only change scoped to the details-page header row; mobile layout is governed by the existing `@media (max-width: 767px)` overrides and is untouched.
- Future considerations: The comment at `ProgramPage.tsx:133` ("Add lucide icon class for specific icons that need white fill") is stale from the Lucide icon migration — optional follow-up cleanup, not required for this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved program card layout by aligning the icon and header consistently.
  * Expanded the header and estimation row across the full card width for better spacing and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->