### PR TITLE
Fix production build: register react-hooks plugin in .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,11 +10,13 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["react"],
+  "plugins": ["react", "react-hooks"],
   "rules": {
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",
     "react/jsx-no-target-blank": "off",
+    "react-hooks/rules-of-hooks": "warn",
+    "react-hooks/exhaustive-deps": "warn",
     "no-console": ["warn", { "allow": ["warn", "error"] }]
   }
 }


### PR DESCRIPTION
## TL;DR

Production builds (`react-scripts build`) fail with
`Definition for rule 'react-hooks/exhaustive-deps' was not found` on 13 files.
This is currently **breaking all staging deploys** (Heroku push rejected) and is the
root cause of the **14 Playwright e2e failures on every open PR**. One-file config fix.

## Root cause

Our root `.eslintrc.json` has `root: true` and only registers the `react` plugin. It
shadows the `eslintConfig` in package.json (`extends: react-app`) that CRA relies on to
load `eslint-plugin-react-hooks` at build time — so the build lints with a config that
has never heard of `react-hooks/*` rules.

This was latent since the file was added: harmless as long as nothing referenced a
react-hooks rule. MFB-1268 (d090c1bf) introduced 13 inline
`eslint-disable-next-line react-hooks/exhaustive-deps` comments — the first references
ever — and every production build since fails, because ESLint treats a disable comment
for an unknown rule as an error.

## Blast radius (all one bug)

- **Staging deploys failing** since MFB-1268 merged — `benefits-calculator-staging` is
  stuck one commit behind main (build log: `Push rejected, failed to compile Node.js app`)
- **Playwright red on every PR** (14 tests): the dev server compiles with ESLint errors,
  CRA's error overlay covers the app, and every test that *clicks* fails; the
  current-benefits tests pass because they only assert text presence
- **Local `npm run build`** fails for everyone

## Fix

Register the plugin (already in devDependencies) and its rules in `.eslintrc.json`:

- `react-hooks/exhaustive-deps: warn` — matches the eslint-config-react-app default;
  the 13 existing disable comments now reference a real rule
- `react-hooks/rules-of-hooks: warn` — deliberately **not** `error` yet: enabling the
  plugin exposed pre-existing violations that were invisible while it was missing:
  - `referrerDataInfo.tsx`: `useIntl` called in `renderLogoSource`, a non-component
  - `FormattedValue.tsx`: `useOverrideValue` called conditionally (3 sites)

  These are potential runtime bugs and need their own ticket; bump the rule to `error`
  once fixed.

## Validation

- `npm run build` → **Compiled with warnings** (was: Failed to compile)
- Merging this should immediately: un-break the staging auto-deploy, and restore the
  Playwright baseline on open PRs

## Follow-ups

- [ ] Ticket for the `rules-of-hooks` violations above, then bump rule to `error`
- [ ] `npm run lint` (`eslint .`) doesn't lint `.tsx` files (no `--ext`), which is why
      CI lint never caught this — worth fixing in a separate PR