### PR TITLE
Elliott/mfb 1305 fix react hooks eslint resolution restore lint at build

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "browser": true,
     "es2021": true
   },
-  "extends": ["plugin:react/recommended", "prettier"],
+  "extends": ["plugin:react/recommended", "plugin:react-hooks/recommended", "prettier"],
   "overrides": [],
   "parserOptions": {
     "ecmaVersion": "latest",
@@ -15,8 +15,6 @@
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",
     "react/jsx-no-target-blank": "off",
-    "react-hooks/rules-of-hooks": "warn",
-    "react-hooks/exhaustive-deps": "warn",
     "no-console": ["warn", { "allow": ["warn", "error"] }]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,11 +10,13 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["react"],
+  "plugins": ["react", "react-hooks"],
   "rules": {
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",
     "react/jsx-no-target-blank": "off",
+    "react-hooks/rules-of-hooks": "warn",
+    "react-hooks/exhaustive-deps": "warn",
     "no-console": ["warn", { "allow": ["warn", "error"] }]
   }
 }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,3 +22,27 @@ jobs:
         with:
           eslint: true
           prettier: true
+
+  # Runs the same `react-scripts build` Heroku runs at deploy time, so
+  # build-breaking lint/compile errors are caught on the PR instead of at
+  # the prod push (see MFB-1305 — lint-action alone missed this class of
+  # failure because `eslint .` doesn't lint .tsx and uses a different config
+  # than the CRA build).
+  production-build:
+    name: Production build (Heroku parity)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js and dependencies
+        uses: ./.github/actions/setup-node-dependencies
+
+      - name: Run production build
+        run: npm run build
+        env:
+          # Match Heroku's build environment (no CI var): hard errors fail the
+          # build, pre-existing warnings don't. Flip to true once the ~31
+          # legacy react-hooks/exhaustive-deps warnings are cleaned up.
+          CI: false

--- a/src/Components/Config/configHook.tsx
+++ b/src/Components/Config/configHook.tsx
@@ -189,7 +189,7 @@ export function useGetConfig(screenLoading: boolean, whiteLabel: string) {
         console.error(`Failed to load config for white label '${whiteLabel}':`, error);
         // Fallback to default config if white label config doesn't exist
         if (whiteLabel !== '_default') {
-          console.log(`Falling back to _default config`);
+          console.warn(`Falling back to _default config`);
           getConfig('_default')
             .then((value: ConfigApiResponse[]) => {
               try {

--- a/src/Components/Confirmation/Confirmation.tsx
+++ b/src/Components/Confirmation/Confirmation.tsx
@@ -40,6 +40,10 @@ const Confirmation = () => {
     return () => {
       document.removeEventListener('keydown', continueOnEnter); // remove event listener on onmount
     };
+    // Intentionally excludes `proceedToResults`/`track`: the handler is recreated
+    // whenever the listener re-binds, and depending on the route identifiers it
+    // reads (navigate/whiteLabel/uuid) re-binds it exactly when its behavior
+    // would change — without re-binding on every render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [navigate, whiteLabel, uuid]);
 

--- a/src/Components/EnergyCalculator/Banner/Banner.tsx
+++ b/src/Components/EnergyCalculator/Banner/Banner.tsx
@@ -18,6 +18,7 @@ const CesnBanner = () => {
       defaultMessage: 'State of Colorado logo',
     }),
     'cesn-header-logo',
+    intl.locale,
   );
 
   return (

--- a/src/Components/EnergyCalculator/Footer/Footer.tsx
+++ b/src/Components/EnergyCalculator/Footer/Footer.tsx
@@ -18,16 +18,19 @@ export default function EnergyCalculatorFooter() {
       defaultMessage: 'Colorado Department of Regulatory Agencies logo',
     }),
     'cesn-footer-dora-logo',
+    intl.locale,
   );
   const mfbLogo = renderLogoSource(
     'PoweredByLogo',
     intl.formatMessage({ id: 'poweredByFooter.logo.alt', defaultMessage: 'Powered by MyFriendBen' }),
     'logo powered-by-footer-logo',
+    intl.locale,
   );
   const raLogo = renderLogoSource(
     'RewiringAmericaLogo',
     intl.formatMessage({ id: 'cesnFooter.raLogo.alt', defaultMessage: 'Rewiring America logo' }),
     'logo powered-by-footer-logo',
+    intl.locale,
   );
   const mfbUrl =
     'https://screener.myfriendben.org/co/step-1?referrer=energy_calculator&utm_source=cesn&utm_medium=web&utm_campaign=cesn&utm_id=cesn';

--- a/src/Components/Referrer/referrerDataInfo.tsx
+++ b/src/Components/Referrer/referrerDataInfo.tsx
@@ -31,7 +31,6 @@ import CESN_Logo_Spanish from '../../Assets/States/CO/WhiteLabels/cesn/CESN_logo
 import CESN_DORA_Color from '../../Assets/States/CO/WhiteLabels/cesn/co_dora_comm_pu_reverse_rgb.png';
 import CESN_Colorado_White from '../../Assets/States/CO/WhiteLabels/cesn/colorado_logo_white.png';
 import HispanicFederation_MFBLogo from '../../Assets/States/NC/WhiteLabels/HispanicFederation/HispanicFederation_MFBLogo.png';
-import { useIntl } from 'react-intl';
 
 const logoMap: { [key: string]: string | undefined } = {
   MFB_COLogo: MFBCOLogo,
@@ -69,9 +68,11 @@ const logoMap: { [key: string]: string | undefined } = {
   HispanicFederation_MFBLogo: HispanicFederation_MFBLogo,
 };
 
-export const renderLogoSource = (sourceLabel: string, logoAlt: string, logoClass: string) => {
-  const intl = useIntl();
-  const currentLanguage = intl.locale;
+// Plain render helper — NOT a hook/component, so it must not call hooks itself
+// (see MFB-1305: useIntl here violated rules-of-hooks). Callers obtain the
+// locale via useIntl() and pass it in.
+export const renderLogoSource = (sourceLabel: string, logoAlt: string, logoClass: string, locale: string) => {
+  const currentLanguage = locale;
 
   let logoSrc = logoMap[sourceLabel] ?? MFBDEFAULT;
 

--- a/src/Components/Referrer/useLogo.tsx
+++ b/src/Components/Referrer/useLogo.tsx
@@ -13,5 +13,5 @@ export const useLogo = (src: keyof ReferrerData, alt: keyof ReferrerData, classN
   // Use meaningful default alt text for accessibility during loading
   const logoAlt = getReferrer(alt, { id: 'logo.alt.default', defaultMessage: 'Organization Logo' }) as MessageDescriptor;
 
-  return renderLogoSource(logoSourceValue.trim(), intl.formatMessage(logoAlt), className);
+  return renderLogoSource(logoSourceValue.trim(), intl.formatMessage(logoAlt), className, intl.locale);
 };

--- a/src/Components/Results/FormattedValue.tsx
+++ b/src/Components/Results/FormattedValue.tsx
@@ -147,12 +147,11 @@ export function useFormatDisplayValue(program: Program) {
   const validation = findValidationForProgram(validations, program);
   const translateNumber = useTranslateNumber();
 
-  if (validation !== undefined) {
-    const expextedValue = translateNumber(formatToUSD(Number(validation.value) / 12));
-    return useOverrideValue(program, value, expextedValue);
-  }
-
-  return useOverrideValue(program, value);
+  // Call the hook unconditionally (rules-of-hooks): expectedValue is simply
+  // undefined when there's no validation, which useOverrideValue handles.
+  const expectedValue =
+    validation !== undefined ? translateNumber(formatToUSD(Number(validation.value) / 12)) : undefined;
+  return useOverrideValue(program, value, expectedValue);
 }
 
 export function YearlyValueLabel({ program }: { program: Program }) {
@@ -182,9 +181,8 @@ export function useFormatYearlyValue(program: Program) {
 
   const value = translateNumber(formatToUSD(programValue(program)));
 
-  if (validation !== undefined) {
-    const expextedValue = translateNumber(formatToUSD(Number(validation.value)));
-    return useOverrideValue(program, value, expextedValue);
-  }
-  return useOverrideValue(program, value);
+  // Call the hook unconditionally (rules-of-hooks): expectedValue is simply
+  // undefined when there's no validation, which useOverrideValue handles.
+  const expectedValue = validation !== undefined ? translateNumber(formatToUSD(Number(validation.value))) : undefined;
+  return useOverrideValue(program, value, expectedValue);
 }

--- a/src/Components/Results/ResultsError/ResultsError.tsx
+++ b/src/Components/Results/ResultsError/ResultsError.tsx
@@ -15,6 +15,8 @@ const ResultsError = () => {
 
   useEffect(() => {
     track('screener_results_error', { reference_id: uuid });
+    // Fire once on mount: this error event should count one impression per
+    // error-screen view, so `track`/`uuid` are intentionally excluded.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/Components/Steps/AlreadyHasBenefits.tsx
+++ b/src/Components/Steps/AlreadyHasBenefits.tsx
@@ -96,6 +96,8 @@ function AlreadyHasBenefits() {
         screener_step_number: hasBenefitsStepNumber >= 0 ? hasBenefitsStepNumber : undefined,
       });
     }
+    // Fire once per error transition: depends only on the error flag so the
+    // event doesn't re-fire on unrelated re-renders (`track`/step number excluded).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasBenefitsProgramsError]);
 

--- a/src/Components/Steps/HouseholdMembers/components/HouseholdMemberBasicInfoPage.tsx
+++ b/src/Components/Steps/HouseholdMembers/components/HouseholdMemberBasicInfoPage.tsx
@@ -46,6 +46,8 @@ const HouseholdMemberBasicInfoPage = () => {
       screener_step_number: currentStepId,
       step_action: 'view',
     });
+    // Fire once on mount (one view event per page visit); `track`/`currentStepId`
+    // are intentionally excluded so re-renders don't re-fire the view.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## TLDR

Production builds broke after MFB-1268: our root .eslintrc.json never loaded eslint-plugin-react-hooks, so the 14 new eslint-disable react-hooks/exhaustive-deps comments referenced a rule ESLint couldn't resolve — a hard error. (exhaustive-deps is the lint rule that checks a useEffect/useMemo dependency array lists everything the callback actually uses — missing deps mean the hook can run against stale values or fail to re-run when inputs change. MFB-1268 intentionally omitted deps on its fire-once analytics effects and used disable comments to say so.) This broke prod (worked around via DISABLE_ESLINT_PLUGIN=true), broke staging deploys, and broke ~14 Playwright tests on every PR (dev-server error overlay intercepts clicks). Fix: register the plugin, individually justify all 14 disables, fix the 5 real rules-of-hooks bugs the plugin exposed (FormattedValue, referrerDataInfo), fix a stray console.log, and add a Heroku-parity production-build CI job so this class of failure lands on the PR, not the prod push. Remove the prod workaround after merge. Remaining gap: 31 legacy exhaustive-deps warnings block CI=true clean builds → MFB-1309.

## Root cause (recap)

`.eslintrc.json` (`root: true`) shadows the package.json `eslintConfig`, so CRA's build
lints without `eslint-plugin-react-hooks`. Latent until MFB-1268 (#2144) added 14 inline
`eslint-disable react-hooks/exhaustive-deps` comments — an unresolvable rule referenced by
a disable comment is a hard error → prod + staging builds broke. Prod was unblocked with
`DISABLE_ESLINT_PLUGIN=true` (workaround); staging has been failing since.

## Changes (mapped to ticket items)

**1. Plugin resolvable** — `.eslintrc.json` extends `plugin:react-hooks/recommended`
(`rules-of-hooks: error`, `exhaustive-deps: warn`), plugin registered.

**2. All 14 MFB-1268 disables reviewed individually** — 10 already had reason comments
(NotificationPopup, ProgramCard, HouseholdMemberForm, Disclaimer, SelectLanguage, stepForm,
SelectStatePage, QuestionComponentContainer, ShareModal, ShareModalAutoPopup). Added
justification comments to the other 4 (Confirmation, ResultsError,
HouseholdMemberBasicInfoPage, AlreadyHasBenefits). All 14 are intentional fire-once /
fire-on-transition analytics effects; none masked a real missing-dep bug. Zero unexplained
disables remain.

**3. All 5 rules-of-hooks violations fixed** (real hook-order hazards):
- `FormattedValue.tsx` (4): `useOverrideValue` was called conditionally/after early return
  in `useFormatDisplayValue` and `useFormatYearlyValue`. Now called unconditionally with
  `expectedValue: string | undefined` — behavior identical. (Also fixed `expextedValue` typo.)
- `referrerDataInfo.tsx` (1): `useIntl` removed from `renderLogoSource` (a plain render
  helper). Callers pass `intl.locale`: EnergyCalculator `Footer` (3 call sites), `Banner`,
  `useLogo`. CESN language-aware logo selection unchanged.

**4. `configHook.tsx:192`** `console.log` → `console.warn`.

**5. CI alignment** — new `production-build` job in `lint.yml` runs the same
`react-scripts build` Heroku runs, so this class of failure fails the PR instead of the
prod push. (Root cause of the CI gap: `eslint .` doesn't lint `.tsx` and uses a different
config than the CRA build.)

## Validation

- `npm run build`: **Compiled with warnings** — zero rule-not-found, zero rules-of-hooks,
  zero no-console. Remaining warnings are the 31 pre-existing exhaustive-deps sites (below).
- Unit tests: 260 passed across the 19 suites covering touched components
  (incl. Footer/Banner which mock `renderLogoSource`).

## Deviation from acceptance criteria — needs a follow-up ticket

"`CI=true npm run build` compiles clean" is **not achievable in this PR**: enabling the
plugin surfaced **31 pre-existing `exhaustive-deps` warnings in 15+ files** untouched by
MFB-1268 (languageOptions, styleController, Header, CurrentBenefits, EnergyCalculator
hooks/providers, questionHooks, Chatbot, …). Under `CI=true`, warnings are errors. Each
needs individual review (adding deps can change runtime behavior). Until then, the new CI
build job runs with `CI: false` (Heroku parity — no CI var is set on Heroku) and should be
flipped to `true` when the cleanup lands.

## Post-merge ops

- [ ] Staging deploy auto-triggers and should succeed — verify
- [ ] Remove the workaround: `heroku config:unset DISABLE_ESLINT_PLUGIN -a benefits-calculator-v1`
      (safe now: hard errors are gone; Heroku doesn't set CI so warnings don't fail builds)
- [ ] Complete https://linear.app/myfriendben/issue/MFB-1309/clean-up-31-legacy-react-hooksexhaustive-deps-warnings-flip-ci
- [ ] Playwright suite on open PRs should recover (dev-server error overlay was intercepting clicks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved locale handling for partner and referral logos, ensuring the appropriate language-specific branding is displayed.
  - Improved diagnostics when the application falls back to its default configuration.

- **Improvements**
  - Strengthened validation and build checks to help prevent issues before release.
  - Improved application reliability by aligning React hook usage with recommended practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->