### PR TITLE
Fix e2e tests

### DIFF
--- a/src/Components/EnergyCalculator/Results/RebatePageMappings.tsx
+++ b/src/Components/EnergyCalculator/Results/RebatePageMappings.tsx
@@ -155,6 +155,26 @@ const ITEM_NAME_MAP: Record<EnergyCalculatorItemType, MessageConfig> = {
     id: 'energyCalculator.rebatePage.title.itemName.wallInsulation',
     defaultMessage: 'wall insulation',
   },
+  new_electric_vehicle: {
+    id: 'energyCalculator.rebatePage.title.itemName.newElectricVehicle',
+    defaultMessage: 'a new electric vehicle',
+  },
+  used_electric_vehicle: {
+    id: 'energyCalculator.rebatePage.title.itemName.usedElectricVehicle',
+    defaultMessage: 'a used electric vehicle',
+  },
+  new_plugin_hybrid_vehicle: {
+    id: 'energyCalculator.rebatePage.title.itemName.newPluginHybridVehicle',
+    defaultMessage: 'a new plug-in hybrid vehicle',
+  },
+  used_plugin_hybrid_vehicle: {
+    id: 'energyCalculator.rebatePage.title.itemName.usedPluginHybridVehicle',
+    defaultMessage: 'a used plug-in hybrid vehicle',
+  },
+  electric_vehicle_charger: {
+    id: 'energyCalculator.rebatePage.title.itemName.electricVehicleCharger',
+    defaultMessage: 'an EV charger',
+  },
 };
 
 /**

--- a/tests/helpers/steps.ts
+++ b/tests/helpers/steps.ts
@@ -61,6 +61,8 @@ export async function selectCondition(page: Page, condition: string) {
 }
 
 export async function selectIncome(page: Page, incomeCategory: string, incomeType: string, frequency: string, amount: number) {
+  await page.locator('button.income-add-button').click();
+  await page.locator('#income-stream-0').waitFor({ state: 'visible' });
   await selectIncomeCategory(page, incomeCategory);
   await selectIncomeType(page, incomeType);
   await selectFrequency(page, frequency);

--- a/tests/helpers/steps.ts
+++ b/tests/helpers/steps.ts
@@ -61,7 +61,9 @@ export async function selectCondition(page: Page, condition: string) {
 }
 
 export async function selectIncome(page: Page, incomeCategory: string, incomeType: string, frequency: string, amount: number) {
-  await page.locator('button.income-add-button').click();
+  // DOB change triggers an async useEffect that auto-appends an empty income stream
+  // for working-age members. Wait for it rather than clicking the add button —
+  // clicking would create a duplicate stream if the effect already fired.
   await page.locator('#income-stream-0').waitFor({ state: 'visible' });
   await selectIncomeCategory(page, incomeCategory);
   await selectIncomeType(page, incomeType);

--- a/tests/helpers/steps.ts
+++ b/tests/helpers/steps.ts
@@ -61,9 +61,6 @@ export async function selectCondition(page: Page, condition: string) {
 }
 
 export async function selectIncome(page: Page, incomeCategory: string, incomeType: string, frequency: string, amount: number) {
-  // DOB change triggers an async useEffect that auto-appends an empty income stream
-  // for working-age members. Wait for it rather than clicking the add button —
-  // clicking would create a duplicate stream if the effect already fired.
   await page.locator('#income-stream-0').waitFor({ state: 'visible' });
   await selectIncomeCategory(page, incomeCategory);
   await selectIncomeType(page, incomeType);


### PR DESCRIPTION

## Context & Motivation

CI was failing on the  [PR-2139](https://github.com/MyFriendBen/benefits-calculator/pull/2139). Two separate bugs were identified as root causes.

- Related PR: [(https://github.com/MyFriendBen/benefits-calculator/pull/2139)]

## Changes Made

- `tests/helpers/steps.ts` — `selectIncome` now waits for `#income-stream-0` to appear instead of clicking the add button, which caused duplicate streams and form validation failures.

- `src/Components/EnergyCalculator/Results/RebatePageMappings.tsx `— Added 5 missing entries to ITEM_NAME_MAP: `new_electric_vehicle`, `used_electric_vehicle`, `new_plugin_hybrid_vehicle`, `used_plugin_hybrid_vehicle`, `electric_vehicle_charger.`

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps: Run `npx playwright test`

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script: None
- Update production config: None
- Admin updates needed: None
- Notify team/users of:

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
- Future considerations:
