### PR TITLE
MFB-1268: emit screener_form_step for the confirmation page

### DIFF
--- a/src/Assets/analytics/stepIds.ts
+++ b/src/Assets/analytics/stepIds.ts
@@ -47,3 +47,11 @@ export const PRE_DIRECTORY_STEP_IDS = {
   disclaimer: 'disclaimer',
   selectState: 'select-state',
 } as const;
+
+// Steps that live AFTER the numbered question directory (so they aren't
+// QuestionNames either): the confirmation page, which sits between the last
+// question and the results page. Kept alongside PRE_DIRECTORY_STEP_IDS so every
+// analytics step slug lives in one place.
+export const POST_DIRECTORY_STEP_IDS = {
+  confirmInformation: 'confirm-information',
+} as const;

--- a/src/Components/Confirmation/Confirmation.tsx
+++ b/src/Components/Confirmation/Confirmation.tsx
@@ -10,6 +10,9 @@ import STEP_CONFIRMATIONS from './ConfirmationSteps';
 import { OTHER_PAGE_TITLES } from '../../Assets/pageTitleTags';
 import { usePageTitle } from '../Common/usePageTitle';
 import { useTrackEvent } from '../../Assets/analytics';
+import { POST_DIRECTORY_STEP_IDS } from '../../Assets/analytics/stepIds';
+
+const CONFIRMATION_STEP_ANALYTICS_ID = POST_DIRECTORY_STEP_IDS.confirmInformation;
 
 const Confirmation = () => {
   const { uuid, whiteLabel } = useParams();
@@ -19,12 +22,32 @@ const Confirmation = () => {
 
   usePageTitle(OTHER_PAGE_TITLES.confirmation);
 
+  // Confirmation sits after the last numbered question, so its step number is
+  // the question count (the page the flow lands on after `step-${count - 1}`).
+  const totalNumberOfQuestions = stepDirectory.length + STARTING_QUESTION_NUMBER;
+
+  // This page lives outside QuestionComponentContainer (its own `confirm-information`
+  // route), so — like Disclaimer — it emits its own funnel view/complete events.
+  useEffect(() => {
+    track('screener_form_step', {
+      screener_step_name: CONFIRMATION_STEP_ANALYTICS_ID,
+      screener_step_number: totalNumberOfQuestions,
+      step_action: 'view',
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Guard so holding Enter (repeated keydown before navigation unmounts) doesn't
   // emit multiple confirmation_proceed / form_complete events.
   const hasProceeded = useRef(false);
   const proceedToResults = () => {
     if (hasProceeded.current) return;
     hasProceeded.current = true;
+    track('screener_form_step', {
+      screener_step_name: CONFIRMATION_STEP_ANALYTICS_ID,
+      screener_step_number: totalNumberOfQuestions,
+      step_action: 'complete',
+    });
     track('screener_confirmation_proceed', {});
     track('screener_form_complete', {});
     navigate(`/${whiteLabel}/${uuid}/results/benefits`);
@@ -52,8 +75,6 @@ const Confirmation = () => {
       return STEP_CONFIRMATIONS[step];
     });
   };
-
-  const totalNumberOfQuestions = useStepDirectory().length + STARTING_QUESTION_NUMBER;
 
   return (
     <main className="benefits-form" data-step-id="confirm-information">


### PR DESCRIPTION
## Why
The confirmation page (`confirm-information` route) fires no `screener_form_step` event, so it's missing from the screener step-drop-off funnel in the analytics dashboards. The funnel currently ends the form at **Sign Up** with nothing for the confirmation screen every user passes through on the way to results. This is the frontend half of the dashboard work in data-queries PR #112.

## What
The confirmation page lives outside `QuestionComponentContainer` (its own route, like the Disclaimer and Select-State screens), so it has to emit its own funnel events. This mirrors [Disclaimer.tsx](src/Components/Steps/Disclaimer/Disclaimer.tsx) exactly:

- **view** — on mount (`useEffect`)
- **complete** — in `proceedToResults()`, alongside the existing `screener_confirmation_proceed` / `screener_form_complete` events (and behind the same `hasProceeded` guard, so holding Enter can't double-fire)

The slug `'confirm-information'` is added to a new `POST_DIRECTORY_STEP_IDS` constant in [stepIds.ts](src/Assets/analytics/stepIds.ts) — a sibling to the existing `PRE_DIRECTORY_STEP_IDS` — so every analytics step slug stays discoverable in one place. Its step number is the question count (the page reached after `step-${count - 1}`), so it orders correctly between the last question and results in the funnel.

Minor: collapses a duplicate `useStepDirectory()` call — `totalNumberOfQuestions` now derives from the existing `stepDirectory` variable.

## Verification
- `tsc --noEmit` clean for both touched files (repo has pre-existing unrelated TS/lint failures under `CI=true` from the just-landed lint-at-build change in #2148 — none in these files).
- Slug matches the dashboard's step-label mapping in `mart_screener_form_funnel` (`'confirm-information' → 'Confirm Information'`), so the step will render with a human label once events flow.

## Note on scope
This adds the **confirmation** step only. The results page intentionally does **not** get a `screener_form_step` event — it's a destination, not a form step, and already fires `screener_results_loaded`, which the funnel's terminal "Reached Results" bar reads (see data-queries #112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)