### PR TITLE
MFB-1306: instrument help-click events (screener_help_click / screener_get_help_click)

### DIFF
--- a/src/Assets/analytics/events.ts
+++ b/src/Assets/analytics/events.ts
@@ -70,14 +70,11 @@ export interface ScreenerEventMap {
   screener_language_changed: StepContext & { language_name: string };
   screener_confirmation_edit: { section: string };
   screener_confirmation_proceed: {};
-  // Inline "?" help-tooltip click (per-step confusion signal). Emitted from ONE
-  // shared tooltip component so every tooltip is tracked identically. help_topic
-  // is REQUIRED so a step's different tooltips stay distinguishable. This is NOT
-  // the results-page "get more help / 211" CTA — that is screener_get_help_click.
-  screener_help_click: StepContext & { help_topic: string };
-  // Results-page "get more help / call 211" CTA. Semantically distinct from inline
-  // field tooltips (screener_help_click) — kept separate so the per-step confusion
-  // metric isn't polluted by a results-page live-help action.
+  // Inline "?" tooltip click, sliced by `help_topic` (a step-identifying slug like
+  // 'income-frequency'). Not the results-page "More Help / 211" CTA below.
+  screener_help_click: { help_topic: string };
+  // Results-page "More Help / 211" CTA — kept separate from screener_help_click so
+  // it doesn't pollute the inline-tooltip confusion metric.
   screener_get_help_click: { location?: string };
 
   // ---- Results: outcomes (fired once on results load) ----

--- a/src/Components/HelpBubbleIcon/HelpButton.tsx
+++ b/src/Components/HelpBubbleIcon/HelpButton.tsx
@@ -3,17 +3,25 @@ import { PropsWithChildren, useContext, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { ReactComponent as HelpBubble } from '../../Assets/icons/helpBubble.svg';
 import { Context } from '../Wrapper/Wrapper';
+import { useTrackEvent } from '../../Assets/analytics';
 import './HelpButton.css';
 
-// `helpTopic` identifies which tooltip this is, so a step's different tooltips
-// stay distinguishable in analytics.
+// `helpTopic` (e.g. "income-frequency") is the slice dimension for
+// screener_help_click — the confusion metric is grouped by topic. Passed by
+// every site so no tooltip logs as 'unknown'.
 type HelpButtonProps = PropsWithChildren<{ className?: string; helpTopic?: string }>;
 
-const HelpButton = ({ className, children }: HelpButtonProps) => {
+const HelpButton = ({ className, children, helpTopic }: HelpButtonProps) => {
   const { getReferrer } = useContext(Context);
   const intl = useIntl();
+  const track = useTrackEvent();
   const [showHelpText, setShowHelpText] = useState(false);
   const handleClick = () => {
+    // Fire on open only (the confusion signal), not close. Single chokepoint, so
+    // no inline "?" tooltip goes untracked.
+    if (!showHelpText) {
+      track('screener_help_click', { help_topic: helpTopic ?? 'unknown' });
+    }
     setShowHelpText((setShow) => !setShow);
   };
   const translatedAriaLabel = intl.formatMessage({ id: 'helpButton.ariaText', defaultMessage: 'help button' });

--- a/src/Components/Results/211Button/211Button.tsx
+++ b/src/Components/Results/211Button/211Button.tsx
@@ -1,12 +1,14 @@
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { useResultsLink } from '../Results';
+import { useTrackEvent } from '../../../Assets/analytics';
 import './211Button.css';
 
 // Results-page "More Help / 211" CTA — NOT the inline "?" tooltip (that is
 // HelpButton in HelpBubbleIcon/).
 const MoreHelpButton = () => {
   const intl = useIntl();
+  const track = useTrackEvent();
   const moreHelpALProps = {
     id: 'helpButton.AL',
     defaultMessage: 'more help button',
@@ -19,7 +21,12 @@ const MoreHelpButton = () => {
       <h2 className="text-center help-text-for-211-button-font">
         <FormattedMessage id="moreHelp.211-header" defaultMessage="Can't find what you need?" />
       </h2>
-      <Link to={moreHelpLink} className="button211" aria-label={intl.formatMessage(moreHelpALProps)}>
+      <Link
+        to={moreHelpLink}
+        className="button211"
+        aria-label={intl.formatMessage(moreHelpALProps)}
+        onClick={() => track('screener_get_help_click', { location: 'results' })}
+      >
         <FormattedMessage id="moreHelp.211-link" defaultMessage="More Help" />
       </Link>
     </div>

--- a/src/Components/Steps/HouseholdAssets/HouseholdAssets.tsx
+++ b/src/Components/Steps/HouseholdAssets/HouseholdAssets.tsx
@@ -72,7 +72,7 @@ const HouseholdAssets = () => {
             id="questions.householdAssets"
             defaultMessage="How much does your whole household have right now in cash, checking or savings accounts, stocks, bonds, or mutual funds?"
           />
-          <HelpButton>
+          <HelpButton helpTopic="household-assets">
             <FormattedMessage
               id="questions.householdAssets-description"
               defaultMessage="In some cases, eligibility for benefits may be affected if your household owns other valuable assets such as a car or life insurance policy."


### PR DESCRIPTION
**Stacked on #2154** (the tooltip-unification refactor). Merge #2154 first. Pure additive instrumentation — one `track()` at the single chokepoint.

- **`screener_help_click`** — fired from the shared `HelpButton` on **open** (not close), with `help_topic` identifying which tooltip. Sites: `household-assets`, `income-frequency`. Because every inline "?" routes through this one component, no tooltip can go silently untracked.
- **`screener_get_help_click`** — fired from the results "More Help / 211" `MoreHelpButton` (`location: 'results'`). Kept separate so the per-step confusion metric isn't polluted by the results-page help CTA.
- Both typed in `events.ts`.

Needs GTM/GA4: new triggers+tags for both events + register `help_topic` dimension.

`tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)