### PR TITLE
Add Education category icon mapping

### DIFF
--- a/src/Components/Results/helpers.ts
+++ b/src/Components/Results/helpers.ts
@@ -15,6 +15,7 @@ export const ICON_NAME_MAP: Record<string, string> = {
   coin: 'coins',
   dental_care: 'smile',
   disability: 'accessibility',
+  education: 'graduation-cap',
   family_planning: 'heart-handshake',
   food: 'apple',
   food_groceries: 'apple',


### PR DESCRIPTION
## Summary

The **Education** program category — used by the Washington State Opportunity Scholarship programs (`wa_wsos_bas` / `wa_wsos_cts` / `wa_wsos_grd`) and the Kansas Promise Scholarship Act (`ks_promise_act`) — was rendering the generic default icon (`circle-dot`) instead of an education-specific one.

**Root cause:** the backend serializes the category icon as the string `"education"` (`ProgramCategory.icon.name`), but `ICON_NAME_MAP` in `src/Components/Results/helpers.ts` had no `education` key. Every consumer resolves `ICON_NAME_MAP[iconKey] ?? ICON_NAME_MAP['default']`, so an unmapped key silently falls back to the default dot.

## Change

- Add `education: 'graduation-cap'` to `ICON_NAME_MAP` (alphabetical position, between `disability` and `family_planning`).

One map entry fixes both WA and KS, since the map is keyed by the icon string (both white labels' configs use `"icon": "education"`), not by white label.

## Why no backend change

The backend `ProgramCategoryDataController.from_model_data` auto-creates the `CategoryIconName` row on config import and already emits `"education"` — the DB/API side is fully handled. This is purely a missing frontend mapping.

## Testing

- `src/Components/Icon/iconMaps.test.tsx` (the guard test asserting every `ICON_NAME_MAP` value resolves to a real Lucide icon) — **57/57 pass**, including the new `education` = `graduation-cap` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying an education-themed graduation cap icon in relevant results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->