### PR TITLE
MFB-1348: screener analytics event improvements

### DIFF
--- a/src/Assets/analytics/errorCodes.test.ts
+++ b/src/Assets/analytics/errorCodes.test.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+import { mfbZodResolver } from './mfbZodResolver';
+import { collectFieldErrors, labelForCode } from './errorLabels';
+
+// The two pieces that make specific error reasons flow to screener_form_error:
+// mfbZodResolver stamps each custom rule's params.code onto the RHF error as
+// `errorCode`, and collectFieldErrors turns the error tree into "field: label"
+// pairs. These assert the analytics contract that silently regresses otherwise.
+
+describe('mfbZodResolver', () => {
+  // Return errors as `any` — these tests assert dynamic per-field shapes the
+  // resolver's union return type ({} | FieldErrors) doesn't narrow to.
+  const call = async (schema: z.ZodType<any>, values: any): Promise<any> => {
+    const { errors } = await mfbZodResolver(schema)(values, undefined, {
+      fields: {},
+      shouldUseNativeValidation: false,
+    } as any);
+    return errors;
+  };
+
+  it('stamps a custom rule code onto a top-level field error', async () => {
+    const schema = z.object({
+      insurance: z.boolean().refine((v) => v === true, { message: 'pick one', params: { code: 'select_one' } }),
+    });
+    const errors = await call(schema, { insurance: false });
+    expect(errors.insurance?.errorCode).toBe('select_one');
+  });
+
+  it('stamps the code at the correct nested/array leaf', async () => {
+    const schema = z.object({
+      members: z.array(
+        z.object({
+          income: z.string().refine((v) => v.length > 0, { message: 'bad', params: { code: 'invalid_amount' } }),
+        }),
+      ),
+    });
+    const errors = await call(schema, { members: [{ income: 'ok' }, { income: '' }] });
+    // Only the second member's income should carry the code.
+    expect(errors.members?.[1]?.income?.errorCode).toBe('invalid_amount');
+    expect(errors.members?.[0]).toBeUndefined();
+  });
+
+  it('leaves standard (non-custom) errors untouched — no errorCode', async () => {
+    const schema = z.object({ name: z.string().min(1) });
+    const errors = await call(schema, { name: '' });
+    expect(errors.name?.errorCode).toBeUndefined();
+    expect(errors.name?.type).toBe('too_small');
+  });
+});
+
+describe('collectFieldErrors', () => {
+  it('prefers errorCode over a bare custom type', () => {
+    const tree = { tcpa: { type: 'custom', message: 'x', errorCode: 'consent_required' } };
+    expect(collectFieldErrors(tree)).toEqual(['tcpa: Consent required']);
+  });
+
+  it('falls back to the zod type when there is no errorCode', () => {
+    const tree = { zip: { type: 'too_small', message: 'x' } };
+    expect(collectFieldErrors(tree)).toEqual(['zip: Required']);
+  });
+
+  it('recurses into nested/array errors to the real leaf', () => {
+    const tree = { members: { 0: { birthYear: { type: 'too_big', message: 'x' } } } };
+    expect(collectFieldErrors(tree)).toEqual(['members.0.birthYear: Too long']);
+  });
+
+  it('maps an unknown code to Invalid', () => {
+    expect(labelForCode('something_new')).toBe('Invalid');
+    expect(collectFieldErrors({ f: { errorCode: 'something_new' } })).toEqual(['f: Invalid']);
+  });
+});

--- a/src/Assets/analytics/errorCodes.test.ts
+++ b/src/Assets/analytics/errorCodes.test.ts
@@ -40,6 +40,19 @@ describe('mfbZodResolver', () => {
     expect(errors.members?.[0]).toBeUndefined();
   });
 
+  it('is first-wins when a path has two coded refines (matches zodResolver)', async () => {
+    // Two custom refines on the same field. zodResolver keeps the first issue;
+    // the stamped errorCode should align with it, not the last one in the loop.
+    const schema = z.object({
+      v: z
+        .string()
+        .refine(() => false, { message: 'a', params: { code: 'first_code' } })
+        .refine(() => false, { message: 'b', params: { code: 'second_code' } }),
+    });
+    const errors = await call(schema, { v: 'x' });
+    expect(errors.v?.errorCode).toBe('first_code');
+  });
+
   it('leaves standard (non-custom) errors untouched — no errorCode', async () => {
     const schema = z.object({ name: z.string().min(1) });
     const errors = await call(schema, { name: '' });

--- a/src/Assets/analytics/errorLabels.ts
+++ b/src/Assets/analytics/errorLabels.ts
@@ -2,8 +2,7 @@
 // the walker that turns an RHF error tree into a "field: label" list for the
 // screener_form_error event's form_error_message. Centralized here so every emit
 // path (the useStepForm hook and any step with its own useForm, e.g. Disclaimer)
-// produces the SAME vocabulary — otherwise the dashboard, which groups on
-// form_error_message, would see divergent text for the same rule.
+// produces the SAME vocabulary for the same rule.
 //
 // PRIVACY: only field path + rule label travel — never the entered value or the
 // localized message (either could carry PII).

--- a/src/Assets/analytics/errorLabels.ts
+++ b/src/Assets/analytics/errorLabels.ts
@@ -1,0 +1,53 @@
+// Shared, PII-safe mapping from validation rule codes to friendly labels, and
+// the walker that turns an RHF error tree into a "field: label" list for the
+// screener_form_error event's form_error_message. Centralized here so every emit
+// path (the useStepForm hook and any step with its own useForm, e.g. Disclaimer)
+// produces the SAME vocabulary — otherwise the dashboard, which groups on
+// form_error_message, would see divergent text for the same rule.
+//
+// PRIVACY: only field path + rule label travel — never the entered value or the
+// localized message (either could carry PII).
+
+// Zod issue codes + custom per-rule codes (set via .refine/.superRefine
+// `params: { code }` and surfaced by mfbZodResolver as `errorCode`).
+export const RULE_LABELS: Record<string, string> = {
+  // standard zod codes
+  too_small: 'Required',
+  invalid_type: 'Required',
+  too_big: 'Too long',
+  invalid_string: 'Invalid format',
+  invalid_enum_value: 'Invalid selection',
+  custom: 'Failed validation',
+  // custom rule codes
+  required: 'Required',
+  select_one: 'Must select an option',
+  none_exclusive: "Can't combine None with others",
+  invalid_amount: 'Invalid amount',
+  hours_required: 'Enter hours worked',
+  future_date: "Date can't be in the future",
+  incomplete: 'Answer all questions',
+  consent_required: 'Consent required',
+  phone_format: 'Must be 10 digits',
+  out_of_area: 'Not in service area',
+  invalid_selection: 'Invalid selection',
+  must_agree: 'Must be checked to continue',
+};
+
+// Map a rule code (or zod type) to its friendly label; unknown -> 'Invalid'.
+export const labelForCode = (code: string | undefined): string =>
+  (code && RULE_LABELS[code]) || 'Invalid';
+
+// Walk an RHF error tree into "field: label" strings. RHF mirrors the form shape,
+// so field arrays (members[0].birthYear) have no `type` at the top level — recurse
+// to the real leaf. A leaf carries an `errorCode` (custom rule, checked first so a
+// refine's bare 'custom' type doesn't win) or a `type` (standard rule).
+export const collectFieldErrors = (node: unknown, path = ''): string[] => {
+  if (!node || typeof node !== 'object') return [];
+  const code = (node as { errorCode?: string }).errorCode;
+  const t = (node as { type?: string }).type;
+  const rule = code ?? t;
+  if (typeof rule === 'string') return [`${path}: ${labelForCode(rule)}`];
+  return Object.entries(node as Record<string, unknown>)
+    .filter(([key]) => key !== 'ref' && key !== 'message' && key !== 'errorCode')
+    .flatMap(([key, child]) => collectFieldErrors(child, path ? `${path}.${key}` : key));
+};

--- a/src/Assets/analytics/events.ts
+++ b/src/Assets/analytics/events.ts
@@ -71,8 +71,9 @@ export interface ScreenerEventMap {
   screener_confirmation_edit: { section: string };
   screener_confirmation_proceed: {};
   // Inline "?" tooltip click, sliced by `help_topic` (a step-identifying slug like
-  // 'income-frequency'). Not the results-page "More Help / 211" CTA below.
-  screener_help_click: { help_topic: string };
+  // 'income-frequency'). screener_step_name lets the dashboard compute a per-step
+  // help rate (clicks ÷ step viewers). Not the results-page "More Help / 211" CTA below.
+  screener_help_click: StepContext & { help_topic: string };
   // Results-page "More Help / 211" CTA — kept separate from screener_help_click so
   // it doesn't pollute the inline-tooltip confusion metric.
   screener_get_help_click: { location?: string };

--- a/src/Assets/analytics/events.ts
+++ b/src/Assets/analytics/events.ts
@@ -71,8 +71,8 @@ export interface ScreenerEventMap {
   screener_confirmation_edit: { section: string };
   screener_confirmation_proceed: {};
   // Inline "?" tooltip click, sliced by `help_topic` (a step-identifying slug like
-  // 'income-frequency'). screener_step_name lets the dashboard compute a per-step
-  // help rate (clicks ÷ step viewers). Not the results-page "More Help / 211" CTA below.
+  // 'income-frequency') and tagged with the hosting step via StepContext. Not the
+  // results-page "More Help / 211" CTA below.
   screener_help_click: StepContext & { help_topic: string };
   // Results-page "More Help / 211" CTA — kept separate from screener_help_click so
   // it doesn't pollute the inline-tooltip confusion metric.

--- a/src/Assets/analytics/mfbZodResolver.ts
+++ b/src/Assets/analytics/mfbZodResolver.ts
@@ -16,6 +16,10 @@ import type { ZodType } from 'zod';
 //
 // PRIVACY: only the code token travels (e.g. 'select_one'), never the localized
 // message or the entered value.
+//
+// Depends on react-hook-form passing the resolver's error objects through
+// verbatim (it does not strip unknown keys like `errorCode`). True as of RHF 7;
+// re-verify if that dependency is upgraded.
 
 const setByPath = (obj: Record<string, any>, path: (string | number)[], code: string) => {
   let node = obj;
@@ -36,6 +40,9 @@ export function mfbZodResolver<T extends FieldValues>(schema: ZodType<any, any, 
     const result = await base(values, context, options);
     // Only enrich when there are errors to enrich.
     if (result.errors && Object.keys(result.errors).length > 0) {
+      // Deliberate second parse: the base resolver has already discarded params,
+      // so there's no way to recover the codes from its output — re-parsing to
+      // read them is the whole reason this wrapper exists. Error path only, cheap.
       const parsed = schema.safeParse(values);
       if (!parsed.success) {
         for (const issue of parsed.error.issues) {

--- a/src/Assets/analytics/mfbZodResolver.ts
+++ b/src/Assets/analytics/mfbZodResolver.ts
@@ -21,13 +21,19 @@ import type { ZodType } from 'zod';
 // verbatim (it does not strip unknown keys like `errorCode`). True as of RHF 7;
 // re-verify if that dependency is upgraded.
 
+// Stamp `code` onto the error node at `path`, but only if it has no errorCode yet
+// — first-wins, matching zodResolver, which keeps the FIRST issue per path. If a
+// path ever gets two coded refines, this keeps our code aligned with the type/
+// message zodResolver kept, instead of letting the last issue in the loop win.
 const setByPath = (obj: Record<string, any>, path: (string | number)[], code: string) => {
   let node = obj;
   for (let i = 0; i < path.length; i++) {
     const key = path[i];
     if (node == null || typeof node !== 'object') return;
     if (i === path.length - 1) {
-      if (node[key] && typeof node[key] === 'object') node[key].errorCode = code;
+      if (node[key] && typeof node[key] === 'object' && node[key].errorCode === undefined) {
+        node[key].errorCode = code;
+      }
     } else {
       node = node[key];
     }

--- a/src/Assets/analytics/mfbZodResolver.ts
+++ b/src/Assets/analytics/mfbZodResolver.ts
@@ -43,7 +43,9 @@ export function mfbZodResolver<T extends FieldValues>(schema: ZodType<any, any, 
       // Deliberate second parse: the base resolver has already discarded params,
       // so there's no way to recover the codes from its output — re-parsing to
       // read them is the whole reason this wrapper exists. Error path only, cheap.
-      const parsed = schema.safeParse(values);
+      // safeParseAsync (matching zodResolver's own parse) so an async refine/
+      // transform added later doesn't throw here.
+      const parsed = await schema.safeParseAsync(values);
       if (!parsed.success) {
         for (const issue of parsed.error.issues) {
           // `params` exists only on custom issues; read it defensively since the

--- a/src/Assets/analytics/mfbZodResolver.ts
+++ b/src/Assets/analytics/mfbZodResolver.ts
@@ -1,0 +1,51 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import type { Resolver, FieldValues } from 'react-hook-form';
+import type { ZodType } from 'zod';
+
+// Drop-in wrapper around zodResolver that preserves a stable per-rule code for
+// custom validators. The stock resolver maps each RHF field error to
+// { message, type: issue.code } and DROPS issue.params — so every .refine() /
+// .superRefine() lands as type 'custom' with no way to tell which rule failed.
+//
+// This wrapper re-runs the schema with safeParse, reads each issue's
+// params.code (set on the custom validators), and stamps it onto the matching
+// field error as `errorCode`, keyed by the issue path. collectErrors
+// (stepForm.tsx) reads `errorCode` for a specific, PII-safe reason — falling
+// back to the zod `type` for standard rules. Transparent for schemas with no
+// params.code, so it is safe to use everywhere zodResolver was used.
+//
+// PRIVACY: only the code token travels (e.g. 'select_one'), never the localized
+// message or the entered value.
+
+const setByPath = (obj: Record<string, any>, path: (string | number)[], code: string) => {
+  let node = obj;
+  for (let i = 0; i < path.length; i++) {
+    const key = path[i];
+    if (node == null || typeof node !== 'object') return;
+    if (i === path.length - 1) {
+      if (node[key] && typeof node[key] === 'object') node[key].errorCode = code;
+    } else {
+      node = node[key];
+    }
+  }
+};
+
+export function mfbZodResolver<T extends FieldValues>(schema: ZodType<any, any, any>): Resolver<T> {
+  const base = zodResolver(schema) as Resolver<T>;
+  return async (values, context, options) => {
+    const result = await base(values, context, options);
+    // Only enrich when there are errors to enrich.
+    if (result.errors && Object.keys(result.errors).length > 0) {
+      const parsed = schema.safeParse(values);
+      if (!parsed.success) {
+        for (const issue of parsed.error.issues) {
+          // `params` exists only on custom issues; read it defensively since the
+          // base ZodIssue type doesn't declare it.
+          const code = (issue as { params?: { code?: string } }).params?.code;
+          if (code) setByPath(result.errors as Record<string, any>, issue.path, code);
+        }
+      }
+    }
+    return result;
+  };
+}

--- a/src/Assets/analytics/stepIds.ts
+++ b/src/Assets/analytics/stepIds.ts
@@ -61,9 +61,9 @@ export const POST_DIRECTORY_STEP_IDS = {
 // screens under one QuestionName ('householdData'): the roster (birth/relationship
 // per member, page 0, shown only when household size > 1) and the per-member
 // detail page (insurance/conditions/income, pages 1..N). Each screen emits its own
-// slug on view/complete/back so the funnel can separate them; the ACTION events
+// slug on the step view/complete/back events; the ACTION events
 // (screener_household_member / screener_income_source) keep the parent
-// 'household-members' slug (their mart groups on it).
+// 'household-members' slug.
 export const HOUSEHOLD_SUBSTEP_IDS = {
   memberBasics: 'member-basics',
   memberDetails: 'member-details',

--- a/src/Assets/analytics/stepIds.ts
+++ b/src/Assets/analytics/stepIds.ts
@@ -60,20 +60,11 @@ export const POST_DIRECTORY_STEP_IDS = {
 // Sub-step slugs for the household-members flow. The member section spans two
 // screens under one QuestionName ('householdData'): the roster (birth/relationship
 // per member, page 0, shown only when household size > 1) and the per-member
-// detail page (insurance/conditions/income, pages 1..N). They emit distinct slugs
-// so the funnel can separate them; view/complete/back all resolve the SAME slug
-// per screen via the household navigation hook.
+// detail page (insurance/conditions/income, pages 1..N). Each screen emits its own
+// slug on view/complete/back so the funnel can separate them; the ACTION events
+// (screener_household_member / screener_income_source) keep the parent
+// 'household-members' slug (their mart groups on it).
 export const HOUSEHOLD_SUBSTEP_IDS = {
   memberBasics: 'member-basics',
   memberDetails: 'member-details',
 } as const;
-
-// The household step routes by page: page 0 is the roster (member-basics), pages
-// 1..N are per-member detail (member-details). Funnel step events (view / complete
-// / back) resolve their slug through this one function so all three agree per page.
-// NOTE: the screener_household_member / screener_income_source ACTION events keep
-// the parent 'household-members' slug (their mart groups on it) — only the funnel
-// step events use these sub-slugs.
-export function getHouseholdSubstepId(pageNumber: number): string {
-  return pageNumber === 0 ? HOUSEHOLD_SUBSTEP_IDS.memberBasics : HOUSEHOLD_SUBSTEP_IDS.memberDetails;
-}

--- a/src/Assets/analytics/stepIds.ts
+++ b/src/Assets/analytics/stepIds.ts
@@ -49,9 +49,31 @@ export const PRE_DIRECTORY_STEP_IDS = {
 } as const;
 
 // Steps that live AFTER the numbered question directory (so they aren't
-// QuestionNames either): the confirmation page, which sits between the last
-// question and the results page. Kept alongside PRE_DIRECTORY_STEP_IDS so every
-// analytics step slug lives in one place.
+// QuestionNames either): the confirmation page and the results page, which sit
+// between the last question and the end of the flow. Kept alongside
+// PRE_DIRECTORY_STEP_IDS so every analytics step slug lives in one place.
 export const POST_DIRECTORY_STEP_IDS = {
   confirmInformation: 'confirm-information',
+  results: 'results',
 } as const;
+
+// Sub-step slugs for the household-members flow. The member section spans two
+// screens under one QuestionName ('householdData'): the roster (birth/relationship
+// per member, page 0, shown only when household size > 1) and the per-member
+// detail page (insurance/conditions/income, pages 1..N). They emit distinct slugs
+// so the funnel can separate them; view/complete/back all resolve the SAME slug
+// per screen via the household navigation hook.
+export const HOUSEHOLD_SUBSTEP_IDS = {
+  memberBasics: 'member-basics',
+  memberDetails: 'member-details',
+} as const;
+
+// The household step routes by page: page 0 is the roster (member-basics), pages
+// 1..N are per-member detail (member-details). Funnel step events (view / complete
+// / back) resolve their slug through this one function so all three agree per page.
+// NOTE: the screener_household_member / screener_income_source ACTION events keep
+// the parent 'household-members' slug (their mart groups on it) — only the funnel
+// step events use these sub-slugs.
+export function getHouseholdSubstepId(pageNumber: number): string {
+  return pageNumber === 0 ? HOUSEHOLD_SUBSTEP_IDS.memberBasics : HOUSEHOLD_SUBSTEP_IDS.memberDetails;
+}

--- a/src/Components/HelpBubbleIcon/HelpButton.tsx
+++ b/src/Components/HelpBubbleIcon/HelpButton.tsx
@@ -10,8 +10,7 @@ import './HelpButton.css';
 // screener_help_click — the confusion metric is grouped by topic. Passed by
 // every site so no tooltip logs as 'unknown'.
 // `stepName` is the analytics step slug of the page hosting the tooltip; the
-// host step passes it (leaf can't resolve it) so the dashboard can compute a
-// per-step help rate. Omit only where no step context applies.
+// host step passes it (the leaf can't resolve it). Omit where no step applies.
 type HelpButtonProps = PropsWithChildren<{ className?: string; helpTopic?: string; stepName?: string }>;
 
 const HelpButton = ({ className, children, helpTopic, stepName }: HelpButtonProps) => {

--- a/src/Components/HelpBubbleIcon/HelpButton.tsx
+++ b/src/Components/HelpBubbleIcon/HelpButton.tsx
@@ -9,9 +9,12 @@ import './HelpButton.css';
 // `helpTopic` (e.g. "income-frequency") is the slice dimension for
 // screener_help_click — the confusion metric is grouped by topic. Passed by
 // every site so no tooltip logs as 'unknown'.
-type HelpButtonProps = PropsWithChildren<{ className?: string; helpTopic?: string }>;
+// `stepName` is the analytics step slug of the page hosting the tooltip; the
+// host step passes it (leaf can't resolve it) so the dashboard can compute a
+// per-step help rate. Omit only where no step context applies.
+type HelpButtonProps = PropsWithChildren<{ className?: string; helpTopic?: string; stepName?: string }>;
 
-const HelpButton = ({ className, children, helpTopic }: HelpButtonProps) => {
+const HelpButton = ({ className, children, helpTopic, stepName }: HelpButtonProps) => {
   const { getReferrer } = useContext(Context);
   const intl = useIntl();
   const track = useTrackEvent();
@@ -20,7 +23,7 @@ const HelpButton = ({ className, children, helpTopic }: HelpButtonProps) => {
     // Fire on open only (the confusion signal), not close. Single chokepoint, so
     // no inline "?" tooltip goes untracked.
     if (!showHelpText) {
-      track('screener_help_click', { help_topic: helpTopic ?? 'unknown' });
+      track('screener_help_click', { help_topic: helpTopic ?? 'unknown', screener_step_name: stepName });
     }
     setShowHelpText((setShow) => !setShow);
   };

--- a/src/Components/PrevAndContinueButtons/PrevAndContinueButtons.tsx
+++ b/src/Components/PrevAndContinueButtons/PrevAndContinueButtons.tsx
@@ -5,12 +5,14 @@ import FormContinueButton from '../ContinueButton/FormContinueButton';
 type PrevAndContinueButtonsProps = {
   backNavigationFunction: () => void;
   disabled?: boolean;
+  // Passed through to the back event's step slug (household sub-pages only).
+  stepNameOverride?: string;
 };
 
-const PrevAndContinueButtons = ({ backNavigationFunction, disabled }: PrevAndContinueButtonsProps) => {
+const PrevAndContinueButtons = ({ backNavigationFunction, disabled, stepNameOverride }: PrevAndContinueButtonsProps) => {
   return (
     <div className="question-buttons">
-      <PreviousButton navFunction={backNavigationFunction} />
+      <PreviousButton navFunction={backNavigationFunction} stepNameOverride={stepNameOverride} />
       <FormContinueButton
         variant="outlined"
         endIcon={<NavigateNextIcon sx={{ ml: '-8px' }} className="rtl-mirror" />}

--- a/src/Components/PreviousButton/PreviousButton.tsx
+++ b/src/Components/PreviousButton/PreviousButton.tsx
@@ -10,9 +10,13 @@ import { getStepAnalyticsId } from '../../Assets/analytics/stepIds';
 
 type Props = {
   navFunction: () => void;
+  // Overrides the route-derived step slug for the back event. Used by the
+  // household sub-pages, whose slug (member-basics / member-details) depends on
+  // the page number, which the route-based resolution here can't see.
+  stepNameOverride?: string;
 };
 
-const PreviousButton = ({ navFunction }: Props) => {
+const PreviousButton = ({ navFunction, stepNameOverride }: Props) => {
   const { formData } = useContext(Context);
   const { whiteLabel, id, uuid } = useParams();
   let stepNumberId = Number(id);
@@ -41,7 +45,7 @@ const PreviousButton = ({ navFunction }: Props) => {
 
   const handleClick = () => {
     track('screener_form_back', {
-      screener_step_name: getStepAnalyticsId(currentStepName),
+      screener_step_name: stepNameOverride ?? getStepAnalyticsId(currentStepName),
       screener_step_number: id ? stepNumberId : undefined,
     });
     navigationFunction();

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -41,6 +41,7 @@ import ShareModalAutoPopup from '../Share/ShareModalAutoPopup';
 import { useFeatureFlag } from '../Config/configHook';
 import { ChatbotProvider } from './Chatbot/Chatbot';
 import { useTrackEvent } from '../../Assets/analytics';
+import { POST_DIRECTORY_STEP_IDS } from '../../Assets/analytics/stepIds';
 import { calculateTotalValue } from './FormattedValue';
 
 // Mounts the Benbot chat widget only when the flag is on; otherwise renders children unchanged.
@@ -182,6 +183,13 @@ const Results = ({ type }: ResultsProps) => {
     track('screener_results_loaded', {
       program_count: apiResults.programs.length,
       total_estimated_value: totalEstimatedValue,
+    });
+
+    // Results as a first-class funnel step, so it joins the step funnel on the
+    // same event/grain as every other step (view only — results is terminal).
+    track('screener_form_step', {
+      screener_step_name: POST_DIRECTORY_STEP_IDS.results,
+      step_action: 'view',
     });
 
     // Per-program impression (the "shown" denominator for conversion). Guarded by

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -185,8 +185,8 @@ const Results = ({ type }: ResultsProps) => {
       total_estimated_value: totalEstimatedValue,
     });
 
-    // Results as a first-class funnel step, so it joins the step funnel on the
-    // same event/grain as every other step (view only — results is terminal).
+    // Emit results as a step view (terminal — view only) so it's tracked on the
+    // same event as every other step.
     track('screener_form_step', {
       screener_step_name: POST_DIRECTORY_STEP_IDS.results,
       step_action: 'view',

--- a/src/Components/Steps/Disclaimer/Disclaimer.tsx
+++ b/src/Components/Steps/Disclaimer/Disclaimer.tsx
@@ -10,6 +10,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { FormattedMessageType } from '../../../Types/Questions';
 import { useTrackEvent } from '../../../Assets/analytics';
 import { PRE_DIRECTORY_STEP_IDS } from '../../../Assets/analytics/stepIds';
+import { collectFieldErrors } from '../../../Assets/analytics/errorLabels';
 import QuestionHeader from '../../QuestionComponents/QuestionHeader';
 import { useConfig, useLocalizedLink } from '../../Config/configHook';
 import ErrorMessageWrapper from '../../ErrorMessage/ErrorMessageWrapper';
@@ -118,16 +119,14 @@ const Disclaimer = () => {
   };
 
   const handleFormError: SubmitErrorHandler<FormSchema> = (formErrors) => {
-    // Build a PII-safe "field: rule" message like the central collectErrors
-    // (stepForm.tsx) — this form uses a plain useForm, so it isn't covered by that.
-    const message = Object.entries(formErrors)
-      .map(([field, err]) => `${field}: ${(err as { errorCode?: string })?.errorCode ?? 'Invalid'}`)
-      .join(', ');
+    // This step uses a plain useForm (not useStepForm), so it emits its own error
+    // event — via the shared collectFieldErrors so form_error_message matches the
+    // rest of the app's vocabulary (the dashboard groups on it).
     track('screener_form_error', {
       screener_step_name: DISCLAIMER_STEP_ANALYTICS_ID,
       screener_step_number: 2,
       form_error_count: Object.keys(formErrors).length,
-      form_error_message: message,
+      form_error_message: collectFieldErrors(formErrors).join(', '),
     });
   };
 

--- a/src/Components/Steps/Disclaimer/Disclaimer.tsx
+++ b/src/Components/Steps/Disclaimer/Disclaimer.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect } from 'react';
 import { Context } from '../../Wrapper/Wrapper';
 import * as z from 'zod';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { mfbZodResolver } from '../../../Assets/analytics/mfbZodResolver';
 import { useForm, Controller, SubmitHandler, SubmitErrorHandler } from 'react-hook-form';
 import { useParams, useNavigate } from 'react-router-dom';
 import { STARTING_QUESTION_NUMBER } from '../../../Assets/stepDirectory';
@@ -78,8 +78,8 @@ const Disclaimer = () => {
   };
 
   const formSchema = z.object({
-    agreeToTermsOfService: z.boolean().refine(isTrue, isChecked()),
-    is13OrOlder: z.boolean().refine(isTrue, isChecked()),
+    agreeToTermsOfService: z.boolean().refine(isTrue, { ...isChecked(), params: { code: 'must_agree' } }),
+    is13OrOlder: z.boolean().refine(isTrue, { ...isChecked(), params: { code: 'must_agree' } }),
   });
 
   type FormSchema = z.infer<typeof formSchema>;
@@ -90,7 +90,7 @@ const Disclaimer = () => {
     getValues,
     handleSubmit,
   } = useForm<FormSchema>({
-    resolver: zodResolver(formSchema),
+    resolver: mfbZodResolver(formSchema),
     defaultValues: {
       agreeToTermsOfService: formData.agreeToTermsOfService ?? false,
       is13OrOlder: formData.is13OrOlder ?? false,
@@ -118,10 +118,16 @@ const Disclaimer = () => {
   };
 
   const handleFormError: SubmitErrorHandler<FormSchema> = (formErrors) => {
+    // Build a PII-safe "field: rule" message like the central collectErrors
+    // (stepForm.tsx) — this form uses a plain useForm, so it isn't covered by that.
+    const message = Object.entries(formErrors)
+      .map(([field, err]) => `${field}: ${(err as { errorCode?: string })?.errorCode ?? 'Invalid'}`)
+      .join(', ');
     track('screener_form_error', {
       screener_step_name: DISCLAIMER_STEP_ANALYTICS_ID,
       screener_step_number: 2,
       form_error_count: Object.keys(formErrors).length,
+      form_error_message: message,
     });
   };
 

--- a/src/Components/Steps/HouseholdAssets/HouseholdAssets.tsx
+++ b/src/Components/Steps/HouseholdAssets/HouseholdAssets.tsx
@@ -15,6 +15,7 @@ import { useParams } from 'react-router-dom';
 import { NumericFormat } from 'react-number-format';
 import useStepForm from '../stepForm';
 import ErrorMessageWrapper from '../../ErrorMessage/ErrorMessageWrapper';
+import { getStepAnalyticsId } from '../../../Assets/analytics/stepIds';
 
 const HouseholdAssets = () => {
   const { formData } = useContext(Context);
@@ -72,7 +73,7 @@ const HouseholdAssets = () => {
             id="questions.householdAssets"
             defaultMessage="How much does your whole household have right now in cash, checking or savings accounts, stocks, bonds, or mutual funds?"
           />
-          <HelpButton helpTopic="household-assets">
+          <HelpButton helpTopic="household-assets" stepName={getStepAnalyticsId('householdAssets')}>
             <FormattedMessage
               id="questions.householdAssets-description"
               defaultMessage="In some cases, eligibility for benefits may be affected if your household owns other valuable assets such as a car or life insurance policy."

--- a/src/Components/Steps/HouseholdMembers/components/HouseholdMemberBasicInfoPage.tsx
+++ b/src/Components/Steps/HouseholdMembers/components/HouseholdMemberBasicInfoPage.tsx
@@ -5,7 +5,7 @@ import { useFieldArray, SubmitHandler } from 'react-hook-form';
 import { Box, Typography, IconButton } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { mfbZodResolver } from '../../../../Assets/analytics/mfbZodResolver';
 import { Context } from '../../../Wrapper/Wrapper';
 import QuestionHeader from '../../../QuestionComponents/QuestionHeader';
 import QuestionDescription from '../../../QuestionComponents/QuestionDescription';
@@ -25,7 +25,7 @@ import DeleteConfirmationPopover from './DeleteConfirmationPopover';
 import '../styles/HouseholdMemberBasicInfoPage.css';
 import type { DeletePopoverState } from '../utils/types';
 import { useTrackEvent } from '../../../../Assets/analytics';
-import { getStepAnalyticsId } from '../../../../Assets/analytics/stepIds';
+import { getStepAnalyticsId, HOUSEHOLD_SUBSTEP_IDS } from '../../../../Assets/analytics/stepIds';
 
 const MAX_HOUSEHOLD_SIZE = 8;
 
@@ -39,14 +39,13 @@ const HouseholdMemberBasicInfoPage = () => {
   const track = useTrackEvent();
 
   // This sub-page is rendered by HouseholdMemberRouter, outside QuestionComponentContainer,
-  // so it tracks its own view. Emits 'household-members' (the parent slug) to stay
-  // consistent with the complete/back events for this step, which both resolve to
-  // 'household-members' via getStepAnalyticsId('householdData'). (Distinct sub-step
-  // slugs would require making PreviousButton/questionHooks sub-step-aware too, so
-  // view/complete/back all agree — a separate change.)
+  // The roster page (page 0). Its funnel step events use the 'member-basics'
+  // sub-slug; back-navigation from the next page resolves the same slug (see the
+  // household nav / PreviousButton). The screener_household_member action events
+  // below keep the parent 'household-members' slug (their mart groups on it).
   useEffect(() => {
     track('screener_form_step', {
-      screener_step_name: getStepAnalyticsId('householdData'),
+      screener_step_name: HOUSEHOLD_SUBSTEP_IDS.memberBasics,
       screener_step_number: currentStepId,
       step_action: 'view',
     });
@@ -94,7 +93,7 @@ const HouseholdMemberBasicInfoPage = () => {
     formState: { errors },
     handleSubmit,
   } = useStepForm<BasicInfoPageSchema>({
-    resolver: zodResolver(formSchema),
+    resolver: mfbZodResolver(formSchema),
     defaultValues: { members: defaultMembers },
     questionName: 'householdData',
     onSubmitSuccessfulOverride: () => {},
@@ -123,7 +122,7 @@ const HouseholdMemberBasicInfoPage = () => {
     // This page navigates manually (onSubmitSuccessfulOverride) instead of through
     // the shared useGoToNextStep hook, so it must fire its own 'complete' event.
     track('screener_form_step', {
-      screener_step_name: getStepAnalyticsId('householdData'),
+      screener_step_name: HOUSEHOLD_SUBSTEP_IDS.memberBasics,
       screener_step_number: currentStepId,
       step_action: 'complete',
     });
@@ -238,7 +237,7 @@ const HouseholdMemberBasicInfoPage = () => {
           </Box>
         )}
 
-        <PrevAndContinueButtons backNavigationFunction={navigateBack} />
+        <PrevAndContinueButtons backNavigationFunction={navigateBack} stepNameOverride={HOUSEHOLD_SUBSTEP_IDS.memberBasics} />
       </form>
 
       <DeleteConfirmationPopover

--- a/src/Components/Steps/HouseholdMembers/components/HouseholdMemberBasicInfoPage.tsx
+++ b/src/Components/Steps/HouseholdMembers/components/HouseholdMemberBasicInfoPage.tsx
@@ -38,11 +38,10 @@ const HouseholdMemberBasicInfoPage = () => {
   const [deletePopover, setDeletePopover] = useState<DeletePopoverState>(null);
   const track = useTrackEvent();
 
-  // This sub-page is rendered by HouseholdMemberRouter, outside QuestionComponentContainer,
-  // The roster page (page 0). Its funnel step events use the 'member-basics'
-  // sub-slug; back-navigation from the next page resolves the same slug (see the
-  // household nav / PreviousButton). The screener_household_member action events
-  // below keep the parent 'household-members' slug (their mart groups on it).
+  // Roster page (page 0), rendered outside QuestionComponentContainer, so it
+  // tracks its own view. Emits the 'member-basics' sub-slug; complete/back use the
+  // same slug. The screener_household_member action events below keep the parent
+  // 'household-members' slug.
   useEffect(() => {
     track('screener_form_step', {
       screener_step_name: HOUSEHOLD_SUBSTEP_IDS.memberBasics,

--- a/src/Components/Steps/HouseholdMembers/components/HouseholdMemberForm.tsx
+++ b/src/Components/Steps/HouseholdMembers/components/HouseholdMemberForm.tsx
@@ -9,7 +9,7 @@ import HouseholdMemberSummaryCards from './HouseholdMemberSummaryCards';
 import { useStepNumber } from '../../../../Assets/stepDirectory';
 import { SubmitHandler, useFieldArray, useWatch } from 'react-hook-form';
 import { useAgeCalculation } from '../../../AgeCalculation/useAgeCalculation';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { mfbZodResolver } from '../../../../Assets/analytics/mfbZodResolver';
 import PrevAndContinueButtons from '../../../PrevAndContinueButtons/PrevAndContinueButtons';
 import useScreenApi from '../../../../Assets/updateScreen';
 import '../styles/IncomeSection.css';
@@ -29,7 +29,7 @@ import StudentEligibilitySection from '../sections/StudentEligibilitySection';
 import IncomeSection from '../sections/IncomeSection';
 import BasicInfoSection from '../sections/BasicInfoSection';
 import { useTrackEvent } from '../../../../Assets/analytics';
-import { getStepAnalyticsId } from '../../../../Assets/analytics/stepIds';
+import { getStepAnalyticsId, HOUSEHOLD_SUBSTEP_IDS } from '../../../../Assets/analytics/stepIds';
 
 const HouseholdMemberForm = () => {
   const isEnergyCalculator = useIsEnergyCalculator();
@@ -69,15 +69,14 @@ const HouseholdMemberForm = () => {
   const currentStepId = useStepNumber(questionName);
   const track = useTrackEvent();
 
-  // This sub-page is rendered by HouseholdMemberRouter, outside QuestionComponentContainer,
-  // so it tracks its own view per member page (pageNumber changes as the user moves
-  // between members, so this intentionally re-fires on each pageNumber change).
+  // The per-member detail page (pages 1..N). Fires a view per member as pageNumber
+  // changes. Uses the 'member-details' sub-slug; complete/back resolve the same
+  // slug so the funnel joins cleanly. (Per-member views make this non-monotonic in
+  // a strict funnel — the dashboard treats member-details as "reached page 1" for
+  // the funnel rung and uses the per-page count only for back-navigation.)
   useEffect(() => {
     track('screener_form_step', {
-      // 'household-members' (parent slug) to stay consistent with this step's
-      // complete/back events. Distinct sub-step slugs need PreviousButton/
-      // questionHooks made sub-step-aware first (separate change).
-      screener_step_name: getStepAnalyticsId(questionName),
+      screener_step_name: HOUSEHOLD_SUBSTEP_IDS.memberDetails,
       screener_step_number: currentStepId,
       step_action: 'view',
     });
@@ -115,7 +114,7 @@ const HouseholdMemberForm = () => {
     clearErrors,
     reset,
   } = useStepForm<any>({
-    resolver: zodResolver(formSchema),
+    resolver: mfbZodResolver(formSchema),
     defaultValues,
     questionName,
     // Provide empty override to prevent automatic navigation - we'll navigate manually in formSubmitHandler
@@ -191,7 +190,7 @@ const HouseholdMemberForm = () => {
       });
     }
     track('screener_form_step', {
-      screener_step_name: getStepAnalyticsId(questionName),
+      screener_step_name: HOUSEHOLD_SUBSTEP_IDS.memberDetails,
       screener_step_number: currentStepId,
       step_action: 'complete',
     });
@@ -326,7 +325,7 @@ const HouseholdMemberForm = () => {
 
       <form onSubmit={handleSubmit(formSubmitHandler, handleFormError)}>
         {renderFormSections()}
-        <PrevAndContinueButtons backNavigationFunction={navigateBack} />
+        <PrevAndContinueButtons backNavigationFunction={navigateBack} stepNameOverride={HOUSEHOLD_SUBSTEP_IDS.memberDetails} />
       </form>
     </main>
   );

--- a/src/Components/Steps/HouseholdMembers/components/HouseholdMemberForm.tsx
+++ b/src/Components/Steps/HouseholdMembers/components/HouseholdMemberForm.tsx
@@ -69,11 +69,8 @@ const HouseholdMemberForm = () => {
   const currentStepId = useStepNumber(questionName);
   const track = useTrackEvent();
 
-  // The per-member detail page (pages 1..N). Fires a view per member as pageNumber
-  // changes. Uses the 'member-details' sub-slug; complete/back resolve the same
-  // slug so the funnel joins cleanly. (Per-member views make this non-monotonic in
-  // a strict funnel — the dashboard treats member-details as "reached page 1" for
-  // the funnel rung and uses the per-page count only for back-navigation.)
+  // Per-member detail page (pages 1..N): emits the 'member-details' sub-slug,
+  // re-firing per member as pageNumber changes. complete/back use the same slug.
   useEffect(() => {
     track('screener_form_step', {
       screener_step_name: HOUSEHOLD_SUBSTEP_IDS.memberDetails,

--- a/src/Components/Steps/HouseholdMembers/sections/IncomeSection.tsx
+++ b/src/Components/Steps/HouseholdMembers/sections/IncomeSection.tsx
@@ -34,7 +34,7 @@ import { IncomeStreamFormData } from '../utils/types';
 import { EMPTY_INCOME_STREAM } from '../utils/constants';
 import { useStepNumber } from '../../../../Assets/stepDirectory';
 import { useTrackEvent } from '../../../../Assets/analytics';
-import { getStepAnalyticsId } from '../../../../Assets/analytics/stepIds';
+import { getStepAnalyticsId, HOUSEHOLD_SUBSTEP_IDS } from '../../../../Assets/analytics/stepIds';
 import '../styles/HouseholdMemberSections.css';
 import '../styles/IncomeSection.css';
 
@@ -178,7 +178,7 @@ const IncomeStreamRow = ({
               <FormLabel id={`income-frequency-label-${index}`} sx={{ fontSize: '0.875rem', fontWeight: 400, color: 'text.primary' }}>
                 <FormattedMessage id="personIncomeBlock.frequency" defaultMessage="Frequency" />
               </FormLabel>
-              <HelpButton helpTopic="income-frequency">
+              <HelpButton helpTopic="income-frequency" stepName={HOUSEHOLD_SUBSTEP_IDS.memberDetails}>
                 <FormattedMessage
                   id="personIncomeBlock.income-freq-help-text"
                   defaultMessage='"Every 2 weeks" means you get paid every other week. "Twice a month" means you get paid two times a month on the same dates each month.'

--- a/src/Components/Steps/HouseholdMembers/utils/schema.ts
+++ b/src/Components/Steps/HouseholdMembers/utils/schema.ts
@@ -81,11 +81,12 @@ const createIncomeSourceSchema = (intl: IntlShape) => {
         .trim()
         .refine(validateIncomeAmount, {
           message: renderIncomeAmountHelperText(intl),
+          params: { code: 'invalid_amount' },
         }),
     })
     .refine(
       (data) => validateHourlyIncome(data.incomeFrequency, data.hoursPerWeek),
-      { message: renderHoursWorkedHelperText(intl), path: ['hoursPerWeek'] }
+      { message: renderHoursWorkedHelperText(intl), path: ['hoursPerWeek'], params: { code: 'hours_required' } }
     );
 };
 
@@ -111,9 +112,11 @@ const createHealthInsuranceSchema = (intl: IntlShape, pageNumber: number) => {
     })
     .refine(hasAtLeastOneTrue, {
       message: renderHealthInsSelectOneHelperText(intl),
+      params: { code: 'select_one' },
     })
     .refine(validateNoneExclusive, {
       message: healthInsNonePlusHelperText,
+      params: { code: 'none_exclusive' },
     });
 };
 
@@ -164,6 +167,7 @@ export const createHouseholdMemberSchema = (
         code: z.ZodIssueCode.custom,
         message: renderFutureBirthMonthHelperText(intl),
         path: ['birthMonth'],
+        params: { code: 'future_date' },
       });
     }
 
@@ -174,6 +178,7 @@ export const createHouseholdMemberSchema = (
             code: z.ZodIssueCode.custom,
             message: renderStudentEligibilityErrorMessage(intl),
             path: ['studentEligibility', name],
+            params: { code: 'incomplete' },
           });
         }
       });

--- a/src/Components/Steps/Referrer.tsx
+++ b/src/Components/Steps/Referrer.tsx
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 import { useParams } from 'react-router-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Controller, SubmitHandler } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { mfbZodResolver } from '../../Assets/analytics/mfbZodResolver';
 import {
   CircularProgress,
   Divider,
@@ -51,6 +51,7 @@ export default function ReferralSourceStep() {
         defaultMessage: 'Please type in your referral source',
       }),
       path: ['otherReferrer'],
+      params: { code: 'required' },
     })
     .transform((val) => {
       if (val.referralSource === 'other') {
@@ -75,7 +76,7 @@ export default function ReferralSourceStep() {
     handleSubmit,
     watch,
   } = useStepForm<FormSchema>({
-    resolver: zodResolver(formSchema),
+    resolver: mfbZodResolver(formSchema),
     defaultValues: {
       referralSource: isOtherSource ? 'other' : formData.referralSource ?? '',
       otherReferrer: isOtherSource ? formData.referralSource ?? '' : '',

--- a/src/Components/Steps/SignUp/SignUp.tsx
+++ b/src/Components/Steps/SignUp/SignUp.tsx
@@ -1,4 +1,4 @@
-import { zodResolver } from '@hookform/resolvers/zod';
+import { mfbZodResolver } from '../../../Assets/analytics/mfbZodResolver';
 import { Checkbox, FormControlLabel, TextField } from '@mui/material';
 import PhoneNumberInput from '../../Common/PhoneNumberInput';
 import { useContext, useEffect, useState } from 'react';
@@ -101,6 +101,7 @@ export const buildContactInfoSchema = (formatMessage: any) => {
             id: 'validation-helperText.phoneNumber',
             defaultMessage: 'Please enter a 10 digit phone number',
           }),
+          params: { code: 'phone_format' },
         }),
       emailConsent: z.boolean(),
       tcpa: z.boolean(),
@@ -108,10 +109,12 @@ export const buildContactInfoSchema = (formatMessage: any) => {
     .refine(({ emailConsent, email }) => email === '' || emailConsent, {
       path: ['emailConsent'],
       message: formatMessage({ id: 'signUp.checkbox.error', defaultMessage: 'Please check the box to continue.' }),
+      params: { code: 'consent_required' },
     })
     .refine(({ tcpa, cell }) => cell === '' || tcpa, {
       path: ['tcpa'],
       message: formatMessage({ id: 'signUp.checkbox.error', defaultMessage: 'Please check the box to continue.' }),
+      params: { code: 'consent_required' },
     })
     .superRefine(({ email, cell, emailConsent, tcpa }, ctx) => {
       const noEmail = email.length === 0;
@@ -127,6 +130,7 @@ export const buildContactInfoSchema = (formatMessage: any) => {
               defaultMessage: 'Please enter an email',
             }),
             path: ['email'],
+            params: { code: 'required' },
           });
         }
         if (noCell) {
@@ -137,6 +141,7 @@ export const buildContactInfoSchema = (formatMessage: any) => {
               defaultMessage: 'Please enter a phone number',
             }),
             path: ['cell'],
+            params: { code: 'required' },
           });
         }
       }
@@ -150,6 +155,7 @@ export const buildContactInfoSchema = (formatMessage: any) => {
               defaultMessage: 'Please enter an email',
             }),
             path: ['email'],
+            params: { code: 'required' },
           });
         }
       }
@@ -163,6 +169,7 @@ export const buildContactInfoSchema = (formatMessage: any) => {
               defaultMessage: 'Please enter a phone number',
             }),
             path: ['cell'],
+            params: { code: 'required' },
           });
         }
       }
@@ -176,11 +183,13 @@ export const buildContactInfoSchema = (formatMessage: any) => {
               defaultMessage: 'Please enter an email or phone number',
             }),
             path: ['email'],
+            params: { code: 'required' },
           });
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: '', // Empty message to just highlight the field
             path: ['cell'],
+            params: { code: 'required' },
           });
         }
       }
@@ -239,7 +248,7 @@ function SignUp() {
     trigger,
     watch,
   } = useStepForm<FormSchema>({
-    resolver: zodResolver(formSchema),
+    resolver: mfbZodResolver(formSchema),
     defaultValues: {
       contactType: {
         sendOffers: formData.signUpInfo.sendOffers,

--- a/src/Components/Steps/Zipcode.tsx
+++ b/src/Components/Steps/Zipcode.tsx
@@ -2,7 +2,7 @@ import { useContext, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { Controller } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { mfbZodResolver } from '../../Assets/analytics/mfbZodResolver';
 import { FormControl, FormHelperText, InputLabel, MenuItem, Select, TextField } from '@mui/material';
 import { PatternFormat } from 'react-number-format';
 import { FormattedMessageType } from '../../Types/Questions';
@@ -62,14 +62,18 @@ export const Zipcode = () => {
     )
     .trim()
     .regex(numberMustBeFiveDigitsLongRegex)
-    .refine((data) => data in countiesByZipcode, { message: errorMessage }); // refine does not use the error map
+    .refine((data) => data in countiesByZipcode, { message: errorMessage, params: { code: 'out_of_area' } }); // refine does not use the error map
 
   const formSchema = z
     .object({
       zipcode: zipcodeSchema,
       county: z.string(),
     })
-    .refine((data) => checkCountyIsValid(data), { message: 'Invalid county', path: ['county'] });
+    .refine((data) => checkCountyIsValid(data), {
+      message: 'Invalid county',
+      path: ['county'],
+      params: { code: 'invalid_selection' },
+    });
 
   type FormSchema = z.infer<typeof formSchema>;
 
@@ -81,7 +85,7 @@ export const Zipcode = () => {
     setValue,
     getValues,
   } = useStepForm<FormSchema>({
-    resolver: zodResolver(formSchema),
+    resolver: mfbZodResolver(formSchema),
     defaultValues: {
       zipcode: formData.zipcode ?? '',
       county: formData.county ?? 'disabled-select',

--- a/src/Components/Steps/stepForm.tsx
+++ b/src/Components/Steps/stepForm.tsx
@@ -6,6 +6,7 @@ import { useGoToNextStep } from '../QuestionComponents/questionHooks';
 import { useStepNumber } from '../../Assets/stepDirectory';
 import { useTrackEvent } from '../../Assets/analytics';
 import { getStepAnalyticsId } from '../../Assets/analytics/stepIds';
+import { collectFieldErrors } from '../../Assets/analytics/errorLabels';
 
 /**
  * This hook is used to create a form for screener steps.
@@ -61,50 +62,10 @@ export default function useStepForm<T extends FieldValues>({
   // attempt, so we emit exactly one error event per failed submit.
   useEffect(() => {
     if (submitCount > 0 && isSubmitted && !isSubmitSuccessful && errorCount > 0) {
-      // "field: label" pairs for which validations failed (e.g.
-      // "zipcode: Required, members.0.birthYear: Invalid format"). PRIVACY: field
-      // path + friendly rule label only — never the entered value or localized
-      // message (either could carry PII). Zod issue codes map to labels below.
-      // Zod issue codes + custom per-rule codes (set on .refine/.superRefine and
-      // surfaced by mfbZodResolver as `errorCode`) -> friendly, PII-safe labels.
-      const RULE_LABELS: Record<string, string> = {
-        // standard zod codes
-        too_small: 'Required',
-        invalid_type: 'Required',
-        too_big: 'Too long',
-        invalid_string: 'Invalid format',
-        invalid_enum_value: 'Invalid selection',
-        custom: 'Failed validation',
-        // custom rule codes
-        required: 'Required',
-        select_one: 'Must select an option',
-        none_exclusive: "Can't combine None with others",
-        invalid_amount: 'Invalid amount',
-        hours_required: 'Enter hours worked',
-        future_date: 'Date can\'t be in the future',
-        incomplete: 'Answer all questions',
-        consent_required: 'Consent required',
-        phone_format: 'Must be 10 digits',
-        out_of_area: 'Not in service area',
-        invalid_selection: 'Invalid selection',
-        must_agree: 'Must be checked to continue',
-      };
-      // Walk into nested/array errors (RHF mirrors the form shape, so household
-      // field arrays like members[0].birthYear have no `type` at the top level)
-      // to report the real leaf field + rule. A leaf is any node carrying an
-      // `errorCode` (custom rule) or `type` (standard) — checking errorCode first
-      // catches refine errors that resolve to a bare 'custom' type otherwise.
-      const collectErrors = (node: unknown, path: string): string[] => {
-        if (!node || typeof node !== 'object') return [];
-        const code = (node as { errorCode?: string }).errorCode;
-        const t = (node as { type?: string }).type;
-        const rule = code ?? t;
-        if (typeof rule === 'string') return [`${path}: ${RULE_LABELS[rule] ?? 'Invalid'}`];
-        return Object.entries(node as Record<string, unknown>)
-          .filter(([key]) => key !== 'ref' && key !== 'message' && key !== 'errorCode')
-          .flatMap(([key, child]) => collectErrors(child, path ? `${path}.${key}` : key));
-      };
-      const errorFields = collectErrors(errors, '').join(', ');
+      // "field: label" pairs for the failed validations (e.g.
+      // "zipcode: Required, members.0.birthYear: Invalid format"), via the shared
+      // collectFieldErrors/RULE_LABELS so every emit path uses one vocabulary.
+      const errorFields = collectFieldErrors(errors).join(', ');
       track('screener_form_error', {
         screener_step_name: getStepAnalyticsId(questionName),
         screener_step_number: stepNumber >= 0 ? stepNumber : undefined,

--- a/src/Components/Steps/stepForm.tsx
+++ b/src/Components/Steps/stepForm.tsx
@@ -65,23 +65,43 @@ export default function useStepForm<T extends FieldValues>({
       // "zipcode: Required, members.0.birthYear: Invalid format"). PRIVACY: field
       // path + friendly rule label only — never the entered value or localized
       // message (either could carry PII). Zod issue codes map to labels below.
+      // Zod issue codes + custom per-rule codes (set on .refine/.superRefine and
+      // surfaced by mfbZodResolver as `errorCode`) -> friendly, PII-safe labels.
       const RULE_LABELS: Record<string, string> = {
+        // standard zod codes
         too_small: 'Required',
         invalid_type: 'Required',
         too_big: 'Too long',
         invalid_string: 'Invalid format',
         invalid_enum_value: 'Invalid selection',
         custom: 'Failed validation',
+        // custom rule codes
+        required: 'Required',
+        select_one: 'Must select an option',
+        none_exclusive: "Can't combine None with others",
+        invalid_amount: 'Invalid amount',
+        hours_required: 'Enter hours worked',
+        future_date: 'Date can\'t be in the future',
+        incomplete: 'Answer all questions',
+        consent_required: 'Consent required',
+        phone_format: 'Must be 10 digits',
+        out_of_area: 'Not in service area',
+        invalid_selection: 'Invalid selection',
+        must_agree: 'Must be checked to continue',
       };
       // Walk into nested/array errors (RHF mirrors the form shape, so household
       // field arrays like members[0].birthYear have no `type` at the top level)
-      // to report the real leaf field + rule rather than a generic 'Invalid'.
+      // to report the real leaf field + rule. A leaf is any node carrying an
+      // `errorCode` (custom rule) or `type` (standard) — checking errorCode first
+      // catches refine errors that resolve to a bare 'custom' type otherwise.
       const collectErrors = (node: unknown, path: string): string[] => {
         if (!node || typeof node !== 'object') return [];
+        const code = (node as { errorCode?: string }).errorCode;
         const t = (node as { type?: string }).type;
-        if (typeof t === 'string') return [`${path}: ${RULE_LABELS[t] ?? 'Invalid'}`];
+        const rule = code ?? t;
+        if (typeof rule === 'string') return [`${path}: ${RULE_LABELS[rule] ?? 'Invalid'}`];
         return Object.entries(node as Record<string, unknown>)
-          .filter(([key]) => key !== 'ref' && key !== 'message')
+          .filter(([key]) => key !== 'ref' && key !== 'message' && key !== 'errorCode')
           .flatMap(([key, child]) => collectErrors(child, path ? `${path}.${key}` : key));
       };
       const errorFields = collectErrors(errors, '').join(', ');


### PR DESCRIPTION
Four related improvements to the app-emitted screener analytics events, surfaced while refining the GA4 dashboard ([data-queries #115](https://github.com/MyFriendBen/data-queries/pull/115)). All forward-only (dbt parses these downstream); PII-safe (slugs/codes only, never entered values or localized text).

## 1. Results as a first-class funnel step
`Results.tsx` fires `screener_form_step { screener_step_name: 'results', step_action: 'view' }` alongside `screener_results_loaded`, so results joins the step funnel on the same event/grain (retires the dbt "furthest step" results-union workaround). New `POST_DIRECTORY_STEP_IDS.results`.

## 2. Specific error rule codes (+ Disclaimer empty-message fix)
The `@hookform/resolvers/zod` resolver drops `issue.params` and maps every custom validator to a bare `type: 'custom'` → "Failed validation" → shows as "Invalid" on the dashboard. Separately, Disclaimer used a plain `useForm` with its own error emit that sent **no** message (the `(unspecified)` rows).
- **New `mfbZodResolver`** wraps `zodResolver`, re-reads each issue's `params.code`, and stamps it onto the RHF error as `errorCode`. Transparent where no code is set, so safe as a drop-in.
- `collectErrors` (stepForm.tsx) reads `errorCode` → specific `RULE_LABELS` entry; falls back to the zod `type` for standard rules, and now also captures refine errors that have no `type`.
- Added `params: { code }` to every custom `.refine`/`.superRefine`: health insurance (`select_one`/`none_exclusive`), income (`invalid_amount`/`hours_required`), birth (`future_date`), student (`incomplete`), signup consents (`consent_required`) + required (`required`), phone (`phone_format`), zip (`out_of_area`), county (`invalid_selection`), referral (`required`), disclaimer (`must_agree`).
- Disclaimer now builds a `field: rule` message and uses `mfbZodResolver`.

## 3. Help-click step context
`HelpButton` takes a `stepName` prop (the host step passes it — the leaf can't resolve it) and includes it on `screener_help_click`, enabling a per-step help rate downstream. Wired the two current call sites (income-frequency → member-details, household-assets → assets).

## 4. Split household-members into member sub-steps
The whole member flow emitted one `household-members` slug. Now:
- Roster page (page 0, shown only for household size > 1) → `member-basics`
- Per-member detail (pages 1..N) → `member-details`
- `view` / `complete` / `back` all resolve the **same** sub-slug per page — back threads through `PrevAndContinueButtons` → `PreviousButton` via a new optional `stepNameOverride` prop, preserving the funnel's view↔complete↔back join.
- The `screener_household_member` / `screener_income_source` **action** events keep the parent `household-members` slug (their dbt mart groups on it — unchanged).

## Verification
- `tsc --noEmit`: 0 new errors (pre-existing count unchanged at 31).
- `react-scripts test`: 325 tests pass across 17 touched suites (HelpButton, PreviousButton, household nav, Disclaimer, SignUp, Zipcode, Referrer, stepForm, …).

## Follow-up (data-queries, separate PR)
Add `member-basics` / `member-details` / `results` to the `screener_step_label` macro + step-funnel ladder: `member-details` becomes the monotonic "reached" rung, `member-basics` sits off the strict ladder (conditionally shown, like referral/select-state), and back-nav stays per-page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation handling across forms, including clearer identification of required fields, invalid selections, dates, amounts, and contact details.
  * Enhanced form error reporting while protecting personally identifiable information.

* **Analytics**
  * Added more precise tracking for household-member sub-steps, results-page views, help interactions, and back navigation.
  * Help interactions now include the relevant screener step context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->