### PR TITLE
MFB-1348: attribute household errors to the member sub-step

### DIFF
--- a/src/Components/Steps/HouseholdMembers/components/HouseholdMemberBasicInfoPage.tsx
+++ b/src/Components/Steps/HouseholdMembers/components/HouseholdMemberBasicInfoPage.tsx
@@ -95,6 +95,7 @@ const HouseholdMemberBasicInfoPage = () => {
     resolver: mfbZodResolver(formSchema),
     defaultValues: { members: defaultMembers },
     questionName: 'householdData',
+    stepNameOverride: HOUSEHOLD_SUBSTEP_IDS.memberBasics,
     onSubmitSuccessfulOverride: () => {},
   });
 

--- a/src/Components/Steps/HouseholdMembers/components/HouseholdMemberForm.tsx
+++ b/src/Components/Steps/HouseholdMembers/components/HouseholdMemberForm.tsx
@@ -114,6 +114,7 @@ const HouseholdMemberForm = () => {
     resolver: mfbZodResolver(formSchema),
     defaultValues,
     questionName,
+    stepNameOverride: HOUSEHOLD_SUBSTEP_IDS.memberDetails,
     // Provide empty override to prevent automatic navigation - we'll navigate manually in formSubmitHandler
     onSubmitSuccessfulOverride: () => {},
   });

--- a/src/Components/Steps/stepForm.tsx
+++ b/src/Components/Steps/stepForm.tsx
@@ -20,10 +20,14 @@ import { collectFieldErrors } from '../../Assets/analytics/errorLabels';
 export default function useStepForm<T extends FieldValues>({
   questionName,
   onSubmitSuccessfulOverride,
+  stepNameOverride,
   ...useFormProps
 }: UseFormProps<T> & {
   questionName: QuestionName;
   onSubmitSuccessfulOverride?: () => void;
+  // Overrides the step slug on the error event. The household sub-pages pass their
+  // sub-step slug so errors attribute to the same slug as their view/back events.
+  stepNameOverride?: string;
 }) {
   const { setStepLoading } = useContext(Context);
   const nextPage = useGoToNextStep(questionName);
@@ -67,7 +71,7 @@ export default function useStepForm<T extends FieldValues>({
       // collectFieldErrors/RULE_LABELS so every emit path uses one vocabulary.
       const errorFields = collectFieldErrors(errors).join(', ');
       track('screener_form_error', {
-        screener_step_name: getStepAnalyticsId(questionName),
+        screener_step_name: stepNameOverride ?? getStepAnalyticsId(questionName),
         screener_step_number: stepNumber >= 0 ? stepNumber : undefined,
         form_error_count: errorCount,
         form_error_message: errorFields,


### PR DESCRIPTION
Follow-up to #2159, found during staging QA.

`screener_form_error` was attributing to the parent `household-members` slug while the household sub-pages' view/complete/back events use the sub-slugs (`member-basics` / `member-details`) from #2159. So member-section errors wouldn't line up with the sub-step rungs on the dashboard funnel.

Fix: `useStepForm` takes an optional `stepNameOverride`; the two household sub-pages pass their sub-slug so the error event resolves the same slug as their other step events.

(This was the last commit on the #2159 branch — it was pushed just after #2159 squash-merged, so it didn't make it into main. The other post-review commits — safeParseAsync, first-wins, comment trims — landed before the squash and are already on main.)

Verified: tsc clean (no new errors), 294 tests pass. Will confirm on staging after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for household member information and details steps.
  * Errors are now associated with the correct step, making troubleshooting and support more accurate.
  * Existing form submission behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->