### PR TITLE
MFB-1351: add missing link_location to Disclaimer inline links

### DIFF
--- a/src/Components/Steps/Disclaimer/Disclaimer.tsx
+++ b/src/Components/Steps/Disclaimer/Disclaimer.tsx
@@ -167,6 +167,7 @@ const Disclaimer = () => {
                     url: publicChargeOption.link,
                     screener_step_name: DISCLAIMER_STEP_ANALYTICS_ID,
                     screener_step_number: 2,
+                    link_location: 'disclaimer_inline',
                   })
                 }
               >
@@ -197,6 +198,7 @@ const Disclaimer = () => {
               url: privacyPolicyLink,
               screener_step_name: DISCLAIMER_STEP_ANALYTICS_ID,
               screener_step_number: 2,
+              link_location: 'disclaimer_inline',
             })
           }
         >
@@ -213,6 +215,7 @@ const Disclaimer = () => {
               url: consentToContactLinks,
               screener_step_name: DISCLAIMER_STEP_ANALYTICS_ID,
               screener_step_number: 2,
+              link_location: 'disclaimer_inline',
             })
           }
         >


### PR DESCRIPTION
Follow-up to #2163 (MFB-1351).

## What

The three inline Disclaimer-step links (Public Charge, Privacy Policy, Terms) were supposed to emit `screener_link_click` with `link_location: 'disclaimer_inline'` (gap #3), but that value was **dropped from #2163** during a revert/re-apply cycle while cleaning up prettier churn. The footer (`'footer'`), zipcode (`'zip_code_inline'`), and needs (`'results_needs'`) values all shipped correctly — only the Disclaimer ones were lost.

## How this was caught

Staging verification (Playwright driving the CO flow, capturing the GTM `dataLayer`): the footer links correctly emitted `link_location: 'footer'`, but the Disclaimer inline Privacy/Terms/Public-Charge links emitted `screener_link_click` with **no `link_location`**. Confirmed against `origin/main` (0 occurrences in Disclaimer.tsx vs. the intended 3), so it was a real shipped gap, not a test artifact.

## Impact

This is exactly the case gap #3 existed to fix: Privacy Policy & Terms appear in **both** the footer and inline on the Disclaimer step. Without `link_location`, the Disclaimer-step clicks can't be separated from footer clicks — dbt classifies them as footer/chrome by name, so Disclaimer engagement is undercounted.

## Change

Adds `link_location: 'disclaimer_inline'` to the three `track('screener_link_click', ...)` calls in `Disclaimer.tsx`. The `events.ts` union already includes `'disclaimer_inline'` (shipped in #2163), so no type change is needed.

## Testing

- Lint clean (0 errors); no new type errors.
- Will re-verify on staging after deploy (footer vs. Disclaimer Privacy/Terms now distinguishable by `link_location`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)