### PR TITLE
MFB-1351: send resource_name on more-help resource clicks

### DIFF
--- a/src/Components/MoreHelp/MoreHelp.tsx
+++ b/src/Components/MoreHelp/MoreHelp.tsx
@@ -11,6 +11,17 @@ type Resource = {
   label?: string;
 };
 
+// The config transform turns each resource's `name` ({_label, _default_message})
+// into a <FormattedMessage>, so its `props.id` is the stable translation label —
+// a PII-free identifier we can use when a resource has no explicit `label`.
+const resourceNameFromConfig = (resource: Resource): string | undefined => {
+  if (resource.label) {
+    return resource.label;
+  }
+  const nameProps = resource.name?.props as { id?: string } | undefined;
+  return nameProps?.id;
+};
+
 const MoreHelp = () => {
   const { moreHelpOptions } = useConfig<{ moreHelpOptions: Resource[] }>('more_help_options');
   const resources: Resource[] = moreHelpOptions;
@@ -32,11 +43,11 @@ const MoreHelp = () => {
                 className="visit-website-btn"
                 target="_blank"
                 onClick={() =>
-                  // `name` is a JSX.Element, so use the config `label` (a plain
-                  // string, PII-free) as the id; resource_index carries the
-                  // ordinal independently (label may be undefined).
+                  // resource_name is the explicit config `label` if set, else the
+                  // translation id behind `name` (both PII-free strings);
+                  // resource_index carries the ordinal as a fallback.
                   track('screener_more_help_resource_click', {
-                    resource_name: resource.label,
+                    resource_name: resourceNameFromConfig(resource),
                     resource_index: index,
                     url: resource.link,
                   })

--- a/src/Components/MoreHelp/MoreHelp.tsx
+++ b/src/Components/MoreHelp/MoreHelp.tsx
@@ -3,7 +3,7 @@ import { useConfig } from '../Config/configHook';
 import { useTrackEvent } from '../../Assets/analytics';
 import './MoreHelp.css';
 
-type Resource = {
+export type Resource = {
   name: JSX.Element;
   description?: JSX.Element;
   link?: string;
@@ -13,13 +13,17 @@ type Resource = {
 
 // The config transform turns each resource's `name` ({_label, _default_message})
 // into a <FormattedMessage>, so its `props.id` is the stable translation label —
-// a PII-free identifier we can use when a resource has no explicit `label`.
-const resourceNameFromConfig = (resource: Resource): string | undefined => {
+// a PII-free identifier we can use when a resource has no explicit `label`. Guard
+// on the element type being FormattedMessage so a differently-shaped `name` (any
+// element with an unrelated `id`) can't leak the wrong value.
+export const resourceNameFromConfig = (resource: Resource): string | undefined => {
   if (resource.label) {
     return resource.label;
   }
-  const nameProps = resource.name?.props as { id?: string } | undefined;
-  return nameProps?.id;
+  if (resource.name?.type === FormattedMessage) {
+    return (resource.name.props as { id?: string }).id;
+  }
+  return undefined;
 };
 
 const MoreHelp = () => {

--- a/src/Components/MoreHelp/resourceNameFromConfig.test.tsx
+++ b/src/Components/MoreHelp/resourceNameFromConfig.test.tsx
@@ -1,0 +1,33 @@
+import { FormattedMessage } from 'react-intl';
+import { resourceNameFromConfig, Resource } from './MoreHelp';
+
+// resourceNameFromConfig picks the analytics resource_name for a more-help
+// resource: an explicit `label` wins, else the translation id from a
+// FormattedMessage `name`, else undefined. It must NOT read `id` off any other
+// element type (that could leak an unrelated DOM id as the resource name).
+
+const resource = (over: Partial<Resource>): Resource => ({
+  name: <FormattedMessage id="moreHelp.default" defaultMessage="Default" />,
+  ...over,
+});
+
+describe('resourceNameFromConfig', () => {
+  it('prefers an explicit label', () => {
+    expect(resourceNameFromConfig(resource({ label: 'my-label' }))).toBe('my-label');
+  });
+
+  it('falls back to the FormattedMessage translation id', () => {
+    expect(
+      resourceNameFromConfig(resource({ name: <FormattedMessage id="moreHelp.two11" defaultMessage="2-1-1" /> })),
+    ).toBe('moreHelp.two11');
+  });
+
+  it('does NOT read id off a non-FormattedMessage element', () => {
+    // A differently-shaped `name` with an unrelated id must not leak that id.
+    expect(resourceNameFromConfig(resource({ name: <div id="not-a-resource-name">x</div> }))).toBeUndefined();
+  });
+
+  it('returns undefined when there is no label and no usable name', () => {
+    expect(resourceNameFromConfig(resource({ name: <span>plain</span> }))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Follow-up to #2163 / #2164 (MFB-1351), from staging QA.

## What

`screener_more_help_resource_click` (the "Visit Website" links on the results **More Help** page) was emitting `resource_name` from the config `label` field — which CO's `more_help_options` don't set. Verified on staging: the event shipped with **no** `resource_name`, only `resource_index` + `url`.

## Fix

The config transform turns each resource's `name` (`{_label, _default_message}`) into a `<FormattedMessage>`, so its `props.id` is the stable translation label. Use that as `resource_name` when an explicit `label` isn't set; fall back to `undefined` (unchanged behavior) if `name` isn't a `FormattedMessage`. No backend/config change needed.

So `resource_name` now lands as a stable translation-label id (e.g. the `_label` behind "2-1-1 Colorado"), which dbt can map to friendly text — rather than being absent.

## Testing

- Verified on staging that the 3 CO more-help resources currently emit only `resource_index` + `url` (no name) — the bug this fixes.
- Change is strictly additive: populates `resource_name` when the id is available, degrades to today's behavior otherwise. Lint clean; no type errors.

## Note for dbt

Once this deploys, `screener_more_help_resource_click.resource_name` will be a translation-label id (stable, PII-free), not a display string. Key the more-help breakdown off `resource_name` (or `url`), and map label → friendly name downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource interaction analytics by consistently recording a non-personally identifiable resource identifier, including when a display label is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->