### PR TITLE
MFB-1569: Add Missouri (MO) white label

### DIFF
--- a/src/Components/Steps/SelectStatePage.tsx
+++ b/src/Components/Steps/SelectStatePage.tsx
@@ -24,6 +24,7 @@ export const STATES: { [key: string]: string } = {
   il: 'Illinois',
   ks: 'Kansas',
   ma: 'Massachusetts',
+  mo: 'Missouri',
   nc: 'North Carolina',
   tx: 'Texas',
   wa: 'Washington',

--- a/src/Types/WhiteLabel.ts
+++ b/src/Types/WhiteLabel.ts
@@ -1,4 +1,4 @@
-export const ALL_VALID_WHITE_LABELS = ['co', 'nc', 'cesn', 'ma', 'il', 'ks', 'tx', 'wa'] as const;
+export const ALL_VALID_WHITE_LABELS = ['co', 'nc', 'cesn', 'ma', 'il', 'ks', 'mo', 'tx', 'wa'] as const;
 
 type ValueOf<T extends readonly any[]> = T[number];
 export type WhiteLabel = ValueOf<typeof ALL_VALID_WHITE_LABELS>;

--- a/src/routes/routes.test.tsx
+++ b/src/routes/routes.test.tsx
@@ -30,16 +30,12 @@ describe('Route Configuration', () => {
     });
 
     it('should have jeffcohs landing pages', () => {
-      const jeffcoPages = CUSTOM_LANDING_PAGES.filter((page) =>
-        page.path.includes('jeffco')
-      );
+      const jeffcoPages = CUSTOM_LANDING_PAGES.filter((page) => page.path.includes('jeffco'));
       expect(jeffcoPages.length).toBeGreaterThan(0);
     });
 
     it('should have cesn landing page', () => {
-      const energyCalcPage = CUSTOM_LANDING_PAGES.find((page) =>
-        page.path.includes('cesn')
-      );
+      const energyCalcPage = CUSTOM_LANDING_PAGES.find((page) => page.path.includes('cesn'));
       expect(energyCalcPage).toBeDefined();
     });
   });
@@ -47,13 +43,14 @@ describe('Route Configuration', () => {
   describe('White Label Routes', () => {
     it('should support all valid white labels', () => {
       // Verify we have the expected white labels defined
-      expect(ALL_VALID_WHITE_LABELS).toHaveLength(8);
+      expect(ALL_VALID_WHITE_LABELS).toHaveLength(9);
       expect(ALL_VALID_WHITE_LABELS).toContain('co');
       expect(ALL_VALID_WHITE_LABELS).toContain('nc');
       expect(ALL_VALID_WHITE_LABELS).toContain('cesn');
       expect(ALL_VALID_WHITE_LABELS).toContain('ma');
       expect(ALL_VALID_WHITE_LABELS).toContain('il');
       expect(ALL_VALID_WHITE_LABELS).toContain('ks');
+      expect(ALL_VALID_WHITE_LABELS).toContain('mo');
       expect(ALL_VALID_WHITE_LABELS).toContain('tx');
       expect(ALL_VALID_WHITE_LABELS).toContain('wa');
     });
@@ -125,12 +122,7 @@ describe('Route Configuration', () => {
 
       const paths = (whiteLabelRoute!.children
         ?.map((route) => route.path)
-        .filter((path) =>
-          typeof path === 'string' &&
-          path !== '' &&
-          !path.startsWith(':') &&
-          !path.includes('*')
-        )
+        .filter((path) => typeof path === 'string' && path !== '' && !path.startsWith(':') && !path.includes('*'))
         .filter(Boolean) || []) as string[];
 
       // Verify each path uses kebab-case

--- a/tests/current-benefits.spec.ts
+++ b/tests/current-benefits.spec.ts
@@ -16,12 +16,7 @@ const TEST_CONFIG: Record<WhiteLabel, { name: string; skip?: boolean; skipReason
   ks: { name: 'Kansas' },
   tx: { name: 'Texas' },
   wa: { name: 'Washington' },
-  mo: {
-    name: 'Missouri',
-    skip: true,
-    skipReason:
-      'MO white label config is not yet loaded on the deployed backend (add_config mo runs post-merge, per MFB-1569). Un-skip once MO config is live.',
-  },
+  mo: { name: 'Missouri' },
 };
 
 // Validate that TEST_CONFIG is in sync with ALL_VALID_WHITE_LABELS

--- a/tests/current-benefits.spec.ts
+++ b/tests/current-benefits.spec.ts
@@ -16,6 +16,12 @@ const TEST_CONFIG: Record<WhiteLabel, { name: string; skip?: boolean; skipReason
   ks: { name: 'Kansas' },
   tx: { name: 'Texas' },
   wa: { name: 'Washington' },
+  mo: {
+    name: 'Missouri',
+    skip: true,
+    skipReason:
+      'MO white label config is not yet loaded on the deployed backend (add_config mo runs post-merge, per MFB-1569). Un-skip once MO config is live.',
+  },
 };
 
 // Validate that TEST_CONFIG is in sync with ALL_VALID_WHITE_LABELS
@@ -25,7 +31,7 @@ if (JSON.stringify(configuredLabels) !== JSON.stringify(allLabels)) {
   throw new Error(
     `TEST_CONFIG is out of sync with ALL_VALID_WHITE_LABELS!\n` +
       `Configured: ${configuredLabels.join(', ')}\n` +
-      `Expected: ${allLabels.join(', ')}`
+      `Expected: ${allLabels.join(', ')}`,
   );
 }
 
@@ -40,94 +46,95 @@ const whiteLabels = ALL_VALID_WHITE_LABELS.map((path) => ({
 test.describe('Current Benefits Pages Test', () => {
   for (const whiteLabel of whiteLabels) {
     const runner = whiteLabel.skip ? test.skip : test;
-    runner(`${whiteLabel.name} current-benefits page loads without [PLACEHOLDER] text or untranslated labels`, async ({
-      page,
-    }) => {
-      const url = `/${whiteLabel.path}/current-benefits`;
+    runner(
+      `${whiteLabel.name} current-benefits page loads without [PLACEHOLDER] text or untranslated labels`,
+      async ({ page }) => {
+        const url = `/${whiteLabel.path}/current-benefits`;
 
-      await test.step(`Navigate to ${url}`, async () => {
-        await page.goto(url);
-        await expect(page).toHaveURL(new RegExp(`${whiteLabel.path}/current-benefits`));
-      });
-      await test.step('Check for [PLACEHOLDER] text and untranslated labels', async () => {
-        /*
-         * Wait for the page to fully load using specific element waits
-         * instead of the less reliable 'networkidle' state
-         */
-        // Wait for the main container to be visible
-        await page.locator('main.benefits-form').waitFor({ state: 'visible', timeout: 60000 });
-        await expect(page.locator('main.benefits-form')).toBeVisible({ timeout: 15000 });
-
-        // Wait for the header to be visible
-        await expect(page.locator('.current-benefits-header')).toBeVisible();
-
-        // Wait for either program categories or loading state to be complete
-        await Promise.any([
-          expect(page.locator('.long-near-term-header').first()).toBeVisible(),
-          expect(page.locator('.category-section-container').first()).toBeVisible(),
-        ]);
-
-        const visibleText = await page.evaluate(() => {
-          return document.body.innerText;
+        await test.step(`Navigate to ${url}`, async () => {
+          await page.goto(url);
+          await expect(page).toHaveURL(new RegExp(`${whiteLabel.path}/current-benefits`));
         });
+        await test.step('Check for [PLACEHOLDER] text and untranslated labels', async () => {
+          /*
+           * Wait for the page to fully load using specific element waits
+           * instead of the less reliable 'networkidle' state
+           */
+          // Wait for the main container to be visible
+          await page.locator('main.benefits-form').waitFor({ state: 'visible', timeout: 60000 });
+          await expect(page.locator('main.benefits-form')).toBeVisible({ timeout: 15000 });
 
-        const foundUntranslatedLabels: string[] = [];
+          // Wait for the header to be visible
+          await expect(page.locator('.current-benefits-header')).toBeVisible();
 
-        const placeholderRegex = /\[PLACEHOLDER\]/gi;
-        const foundPlaceholders = visibleText.match(placeholderRegex) || [];
+          // Wait for either program categories or loading state to be complete
+          await Promise.any([
+            expect(page.locator('.long-near-term-header').first()).toBeVisible(),
+            expect(page.locator('.category-section-container').first()).toBeVisible(),
+          ]);
 
-        /*
-         * Using 'TreeWalker' to get collect all of the
-         * text nodes on the page.
-         */
-        const textContent = await page.evaluate(() => {
-          const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+          const visibleText = await page.evaluate(() => {
+            return document.body.innerText;
+          });
 
-          let node: Node | null;
-          const textNodes: string[] = [];
+          const foundUntranslatedLabels: string[] = [];
+
+          const placeholderRegex = /\[PLACEHOLDER\]/gi;
+          const foundPlaceholders = visibleText.match(placeholderRegex) || [];
 
           /*
-           * 'walker.nextNode()' returns the next node or null
-           * when it reaches the end of the document. The while loop
-           * will continue to run until 'walker.nextNode()' returns
-           * null.
+           * Using 'TreeWalker' to get collect all of the
+           * text nodes on the page.
            */
-          while ((node = walker.nextNode())) {
-            const text = node.textContent?.trim();
-            if (text && text.length > 0) {
-              textNodes.push(text);
+          const textContent = await page.evaluate(() => {
+            const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+
+            let node: Node | null;
+            const textNodes: string[] = [];
+
+            /*
+             * 'walker.nextNode()' returns the next node or null
+             * when it reaches the end of the document. The while loop
+             * will continue to run until 'walker.nextNode()' returns
+             * null.
+             */
+            while ((node = walker.nextNode())) {
+              const text = node.textContent?.trim();
+              if (text && text.length > 0) {
+                textNodes.push(text);
+              }
+            }
+
+            return textNodes;
+          });
+
+          const untranslatedLabelPatterns = [
+            /program\.[a-z0-9_-]+/,
+            /program_category\.[a-z0-9_-]+/,
+            /urgent_need\.[a-z0-9_-]+/,
+          ];
+
+          for (const text of textContent) {
+            for (const pattern of untranslatedLabelPatterns) {
+              if (pattern.test(text.trim())) {
+                foundUntranslatedLabels.push(text.trim());
+              }
             }
           }
 
-          return textNodes;
+          const uniqueUntranslatedLabels = [...new Set(foundUntranslatedLabels)];
+          const totalIssues = foundPlaceholders.length + uniqueUntranslatedLabels.length;
+
+          if (totalIssues > 0) {
+            // Fail the test with a detailed message
+            expect(
+              totalIssues,
+              `Found ${totalIssues} issues in ${whiteLabel.path}/current-benefits: ` +
+                `${foundPlaceholders.length} [PLACEHOLDER], ${uniqueUntranslatedLabels.length} untranslated labels`,
+            ).toBe(0);
+          }
         });
-
-        const untranslatedLabelPatterns = [
-          /program\.[a-z0-9_-]+/,
-          /program_category\.[a-z0-9_-]+/,
-          /urgent_need\.[a-z0-9_-]+/,
-        ];
-
-        for (const text of textContent) {
-          for (const pattern of untranslatedLabelPatterns) {
-            if (pattern.test(text.trim())) {
-              foundUntranslatedLabels.push(text.trim());
-            }
-          }
-        }
-
-        const uniqueUntranslatedLabels = [...new Set(foundUntranslatedLabels)];
-        const totalIssues = foundPlaceholders.length + uniqueUntranslatedLabels.length;
-
-        if (totalIssues > 0) {
-          // Fail the test with a detailed message
-          expect(
-            totalIssues,
-            `Found ${totalIssues} issues in ${whiteLabel.path}/current-benefits: ` +
-              `${foundPlaceholders.length} [PLACEHOLDER], ${uniqueUntranslatedLabels.length} untranslated labels`,
-          ).toBe(0);
-        }
-      });
-    });
+      },
+    );
   }
 });


### PR DESCRIPTION
## Summary

Registers **Missouri (`mo`)** as a valid white label on the frontend so the `/mo/*` routes resolve and Missouri appears in the state selector. Pairs with the backend config PR ([benefits-api#1667](https://github.com/MyFriendBen/benefits-api/pull/1667)).

Linear: [MFB-1569](https://linear.app/myfriendben/issue/MFB-1569/mo-configure-missouri-white-label)

## Changes

- `src/Types/WhiteLabel.ts` — add `'mo'` to `ALL_VALID_WHITE_LABELS`.
- `src/Components/Steps/SelectStatePage.tsx` — add `mo: 'Missouri'` to the `STATES` map so it shows in the "What is your state?" dropdown.
- `src/routes/routes.test.tsx` — update the white-label assertions (count 8 → 9, assert `'mo'` present). Prettier also normalized a few pre-existing multi-line expressions in this file.

## Testing

- `react-scripts test src/routes/routes.test.tsx` → 14 passed (incl. "should support all valid white labels")
- `tsc --noEmit` → no new errors in the changed files (pre-existing errors elsewhere are unrelated)
- `prettier` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Missouri as a selectable state.
  * Added Missouri to the available white-label options.
* **Tests**
  * Updated routing assertions to include Missouri and validate related custom landing page paths.
  * Refined route path pattern checks to improve coverage.
  * Updated current-benefits Playwright coverage by skipping Missouri until it’s available in the deployed backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->