### PR TITLE
Hide KS and MO from the public state dropdown

### DIFF
--- a/src/Components/Steps/SelectStatePage.tsx
+++ b/src/Components/Steps/SelectStatePage.tsx
@@ -25,7 +25,9 @@ const SELECT_STATE_STEP_ANALYTICS_ID = PRE_DIRECTORY_STEP_IDS.selectState;
 export const STATES: { [key: string]: string } = {
   co: 'Colorado',
   il: 'Illinois',
+  // ks: 'Kansas',
   ma: 'Massachusetts',
+  // mo: 'Missouri',
   nc: 'North Carolina',
   tx: 'Texas',
   wa: 'Washington',

--- a/src/Components/Steps/SelectStatePage.tsx
+++ b/src/Components/Steps/SelectStatePage.tsx
@@ -19,12 +19,13 @@ import { PRE_DIRECTORY_STEP_IDS } from '../../Assets/analytics/stepIds';
 
 const SELECT_STATE_STEP_ANALYTICS_ID = PRE_DIRECTORY_STEP_IDS.selectState;
 
+// States shown in the public "What is your state?" dropdown. A white label can
+// be live and directly reachable at /{state} (see ALL_VALID_WHITE_LABELS) without
+// appearing here — KS and MO are omitted because they are not yet publicly launched.
 export const STATES: { [key: string]: string } = {
   co: 'Colorado',
   il: 'Illinois',
-  ks: 'Kansas',
   ma: 'Massachusetts',
-  mo: 'Missouri',
   nc: 'North Carolina',
   tx: 'Texas',
   wa: 'Washington',


### PR DESCRIPTION
## What

Removes `ks` (Kansas) and `mo` (Missouri) from the `STATES` object that populates the "What is your state?" dropdown on the Select State step.

## Why

Both are live white labels and deployed to prod, but neither has been publicly launched — MO especially is not being shared with anyone yet. They should not be selectable from the public dropdown until launch.

## Scope / what this does NOT change

- **Routing is untouched.** `ks` and `mo` remain in `ALL_VALID_WHITE_LABELS`, so `/ks` and `/mo` (and their sub-steps) still resolve. This keeps them reachable for internal QA and any direct partner links — they're just not advertised in the dropdown.
- No translation, config, or backend changes.

## Testing

- `src/routes/routes.test.tsx` — 14/14 passing (asserts on `ALL_VALID_WHITE_LABELS`, which is unchanged).
- Lint clean under project config.

## To re-enable at launch

Add the state back to the `STATES` object in `src/Components/Steps/SelectStatePage.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed Kansas and Missouri from the publicly available state selection dropdown.
  - Existing direct links to these states remain accessible where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->