### PR TITLE
MFB-1599: NC : CCLA Cobrand Follow-Up

### DIFF
--- a/src/Components/CclaComponents/CclaFooter/CclaFooter.css
+++ b/src/Components/CclaComponents/CclaFooter/CclaFooter.css
@@ -20,9 +20,13 @@
   flex-direction: row;
 }
 
-.footer-paragraph {
+.ccla-footer-paragraph {
   margin-bottom: 1rem;
   text-align: center;
+}
+
+.ccla-footer-paragraph .MuiTypography-root {
+  font-size: 0.625rem;
 }
 
 .first-paragraph {

--- a/src/Components/CclaComponents/CclaFooter/CclaFooter.tsx
+++ b/src/Components/CclaComponents/CclaFooter/CclaFooter.tsx
@@ -92,8 +92,8 @@ const CclaFooter = () => {
 
   return (
     <>
-      <Box className="flex-row footer-paragraph first-paragraph">{displayFirstParagraph()}</Box>
-      <Box className="flex-row footer-paragraph second-paragraph">{displaySecondParagraph()}</Box>
+      <Box className="flex-row ccla-footer-paragraph first-paragraph">{displayFirstParagraph()}</Box>
+      <Box className="flex-row ccla-footer-paragraph second-paragraph">{displaySecondParagraph()}</Box>
       <Footer hideServiceLinks={true} />
       <Paper elevation={0} sx={{ width: '100%', backgroundColor: '#efefef', padding: '1rem 1rem' }} square={true}>
         {displayCopyrightPolicySection()}


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes [MFB-1599](https://linear.app/myfriendben/issue/MFB-1599/nc-ccla-cobrand-follow-up)
- Related PR: [MFB-1173: NC-Implement Cobrand with Charlotte Center for Legal Advocacy](https://github.com/MyFriendBen/benefits-calculator/pull/2139)

## Changes Made

Resized the disclaimer text at the bottom of the CCLA cobrand footer to match the smaller text size in the LANC cobrand.

<img width="2148" height="1538" alt="Screenshot 2026-08-05 at 2 43 15 PM" src="https://github.com/user-attachments/assets/1bee98bf-2e90-4911-aa88-65b533678586" />

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps: 

1. Navigate to http://localhost:3000/nc/step-1?referrer=ccla
2. Scroll to the footer — disclaimer text should be visibly smaller (matching LANC at `?referrer=lanc`)

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script: None
- Update production config: None
- Admin updates needed: None
- Notify team/users of: None

## Notes for Reviewers

No functional changes, styling only.

- Known limitations:
- Future considerations:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated CCLA footer paragraph styling for more consistent presentation.
  * Adjusted footer typography to use a smaller text size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->