### PR TITLE
MFB-1575: Delete mismatched household assets tooltip

### DIFF
--- a/src/Components/Steps/HouseholdAssets/HouseholdAssets.tsx
+++ b/src/Components/Steps/HouseholdAssets/HouseholdAssets.tsx
@@ -1,7 +1,6 @@
 import { Controller, SubmitHandler } from 'react-hook-form';
 import { InputAdornment, TextField } from '@mui/material';
 import { FormattedMessage, useIntl } from 'react-intl';
-import HelpButton from '../../HelpBubbleIcon/HelpButton';
 import QuestionHeader from '../../QuestionComponents/QuestionHeader';
 import QuestionQuestion from '../../QuestionComponents/QuestionQuestion';
 import PrevAndContinueButtons from '../../PrevAndContinueButtons/PrevAndContinueButtons';
@@ -15,7 +14,6 @@ import { useParams } from 'react-router-dom';
 import { NumericFormat } from 'react-number-format';
 import useStepForm from '../stepForm';
 import ErrorMessageWrapper from '../../ErrorMessage/ErrorMessageWrapper';
-import { getStepAnalyticsId } from '../../../Assets/analytics/stepIds';
 
 const HouseholdAssets = () => {
   const { formData } = useContext(Context);

--- a/src/Components/Steps/HouseholdAssets/HouseholdAssets.tsx
+++ b/src/Components/Steps/HouseholdAssets/HouseholdAssets.tsx
@@ -68,18 +68,10 @@ const HouseholdAssets = () => {
         <FormattedMessage id="qcc.about_household" defaultMessage="Tell us about your household" />
       </QuestionHeader>
       <QuestionQuestion>
-        <>
-          <FormattedMessage
-            id="questions.householdAssets"
-            defaultMessage="How much does your whole household have right now in cash, checking or savings accounts, stocks, bonds, or mutual funds?"
-          />
-          <HelpButton helpTopic="household-assets" stepName={getStepAnalyticsId('householdAssets')}>
-            <FormattedMessage
-              id="questions.householdAssets-description"
-              defaultMessage="In some cases, eligibility for benefits may be affected if your household owns other valuable assets such as a car or life insurance policy."
-            />
-          </HelpButton>
-        </>
+        <FormattedMessage
+          id="questions.householdAssets"
+          defaultMessage="How much does your whole household have right now in cash, checking or savings accounts, stocks, bonds, or mutual funds?"
+        />
       </QuestionQuestion>
       <form onSubmit={handleSubmit(formSubmitHandler)}>
         <Controller


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes [MFB-1575](https://linear.app/myfriendben/issue/MFB-1575/delete-assets-tooltip) — reported by NWIRP (WA partner)
- Related PR: n/a

The household assets question asks specifically about **liquid** assets ("cash, checking or savings accounts, stocks, bonds, or mutual funds"), but the adjacent "?" tooltip read: *"In some cases, eligibility for benefits may be affected if your household owns other valuable assets such as a car or life insurance policy."*

The tooltip implied non-liquid assets (a car, a life insurance policy) should be counted in this field. They should not. The mismatch risked users **over**-reporting assets into a liquid-assets field and getting inaccurate eligibility results. Per the ticket's acceptance criteria, the tooltip is deleted rather than reworded.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- `src/Components/Steps/HouseholdAssets/HouseholdAssets.tsx`
  - Removed the `<HelpButton>` tooltip and its `questions.householdAssets-description` message from the household assets question.
  - Unwrapped the now-unnecessary `<>...</>` fragment so `<QuestionQuestion>` holds the single `FormattedMessage` directly.
  - Dropped the imports that became unused as a result: `HelpButton` and `getStepAnalyticsId`.
- The `questions.householdAssets` question text itself is unchanged.
- Net: 4 insertions, 14 deletions in one file. No other files touched.

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: none
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  1. `npm run dev`, start a screener and advance to the household assets step (`/step-7` on WA; step index varies by white label).
  2. Confirm the question text still renders in full and **no "?" help icon** appears beside it.
  3. Enter a value and Continue — verify the form still submits and `householdAssets` persists on back-navigation.
  4. Confirm other tooltips are unaffected (e.g. the income-frequency "?" in the household member income section still opens).
- Automated checks run locally:
  - `npx tsc --noEmit` — no new errors; zero errors in `Steps/HouseholdAssets/` (the 29 reported errors are pre-existing repo-wide and untouched by this branch).
  - `npx react-scripts build` — compiles; no warnings attributable to `HouseholdAssets.tsx`.
  - `react-scripts test --testPathPattern=Expenses` — 24/24 passing (nearest suite exercising `householdAssets` form data).
  - `npx eslint` on the file reports a parsing error, but it reproduces identically on the pre-change file — pre-existing lint config issue, not introduced here.

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: none. This only removes a rendered string; no new translation IDs are introduced, so `add_translations` does **not** need to run.
- Production config updates: none
- Admin updates needed: none required. Optional cleanup — the `questions.householdAssets-description` row is now orphaned in the backend `Translation` table (no code references it). Safe to leave in place; can be purged later if desired.
- Notify team/users of: NWIRP, who reported it. Worth flagging to whoever owns screener analytics that `screener_help_click` will stop emitting the `household-assets` `help_topic` value, so that series goes flat from this deploy forward.

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
  - This resolves the contradiction by deletion, which is what the AC asked for. It does not answer the ticket's underlying policy question of whether a car or life insurance policy *should* count toward asset limits for any program. If some program's asset test genuinely does count non-liquid assets, that's a separate calculator/copy discussion, not a tooltip one.
  - No dedicated unit test was added for a tooltip's absence; there is no existing `HouseholdAssets.test.tsx` to extend, and asserting on the removal of an element felt low-value relative to adding a whole suite. Happy to add one if reviewers prefer.
- Future considerations:
  - `helpTopic` is a free-form `string` on `HelpButton` with no central registry, so removing a tooltip leaves no compile-time trace. If tooltip coverage is something we want to track deliberately, narrowing `helpTopic` to a union type would make additions and removals visible in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the household assets question by removing supplementary guidance and the help bubble.
  * The screen now displays only the main prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->