### PR TITLE
MFB-1603: fall back to generic legal links when config value is empty

### DIFF
--- a/src/Components/Config/configHook.test.tsx
+++ b/src/Components/Config/configHook.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import { renderHook, waitFor } from '@testing-library/react';
-import { useGetConfig, useFeatureFlag } from './configHook';
+import { useGetConfig, useFeatureFlag, useLocalizedLink } from './configHook';
 import { Context } from '../Wrapper/Wrapper';
 import { WrapperContext } from '../../Types/WrapperContext';
 import { PropsWithChildren } from 'react';
@@ -376,5 +376,92 @@ describe('useFeatureFlag', () => {
     const wrapper = createWrapper(undefined);
     const { result } = renderHook(() => useFeatureFlag('eligibility_tags'), { wrapper });
     expect(result.current).toBe(false);
+  });
+});
+
+describe('useLocalizedLink', () => {
+  const GENERIC_PRIVACY_POLICY = 'https://www.myfriendben.org/privacy-policy/';
+  const GENERIC_TERMS = 'https://www.myfriendben.org/terms-and-conditions/';
+
+  const createWrapper = (config: Config | undefined, locale = 'en-us') => {
+    const contextValue = {
+      config,
+      configLoading: false,
+      formData: {} as any,
+      setFormData: jest.fn(),
+      locale: locale as any,
+      selectLanguage: jest.fn(),
+      getReferrer: jest.fn(() => '') as any,
+      theme: {} as any,
+      setTheme: jest.fn(),
+      styleOverride: undefined,
+      stepLoading: false,
+      setStepLoading: jest.fn(),
+      pageIsLoading: false,
+      setScreenLoading: jest.fn(),
+      staffToken: undefined,
+      setStaffToken: jest.fn(),
+      whiteLabel: '',
+      setWhiteLabel: jest.fn(),
+      referralOptions: { generic: {}, partners: {} },
+      referralOptionsLoading: false,
+      referralOptionsError: null,
+      hasBenefitsPrograms: [],
+      hasBenefitsProgramsLoading: false,
+      hasBenefitsProgramsError: false,
+    } as WrapperContext;
+
+    return ({ children }: PropsWithChildren) => (
+      <Context.Provider value={contextValue}>{children}</Context.Provider>
+    );
+  };
+
+  it('should return the link for the current locale', () => {
+    const wrapper = createWrapper(
+      { privacy_policy: { 'en-us': GENERIC_PRIVACY_POLICY, es: 'https://www.myfriendben.org/privacidad/' } },
+      'es',
+    );
+    const { result } = renderHook(() => useLocalizedLink('privacy_policy'), { wrapper });
+    expect(result.current).toBe('https://www.myfriendben.org/privacidad/');
+  });
+
+  it('should fall back to en-us for a locale without its own translated page', () => {
+    const wrapper = createWrapper({ privacy_policy: { 'en-us': GENERIC_PRIVACY_POLICY } }, 'vi');
+    const { result } = renderHook(() => useLocalizedLink('privacy_policy'), { wrapper });
+    expect(result.current).toBe(GENERIC_PRIVACY_POLICY);
+  });
+
+  // KS, MO, and WA shipped with {"en-us": ""} in the config, which rendered the footer and
+  // consent links with an empty href. An empty string must fall through to the generic page.
+  it('should fall back to the generic page when the configured link is an empty string', () => {
+    const wrapper = createWrapper({ privacy_policy: { 'en-us': '' }, consent_to_contact: { 'en-us': '' } });
+    const { result: privacy } = renderHook(() => useLocalizedLink('privacy_policy'), { wrapper });
+    const { result: terms } = renderHook(() => useLocalizedLink('consent_to_contact'), { wrapper });
+    expect(privacy.current).toBe(GENERIC_PRIVACY_POLICY);
+    expect(terms.current).toBe(GENERIC_TERMS);
+  });
+
+  it('should fall back to the generic page when the locale link is empty but en-us is set', () => {
+    const wrapper = createWrapper({ privacy_policy: { 'en-us': GENERIC_PRIVACY_POLICY, es: '' } }, 'es');
+    const { result } = renderHook(() => useLocalizedLink('privacy_policy'), { wrapper });
+    expect(result.current).toBe(GENERIC_PRIVACY_POLICY);
+  });
+
+  it('should fall back to the generic page when the config key is absent', () => {
+    const wrapper = createWrapper({});
+    const { result } = renderHook(() => useLocalizedLink('consent_to_contact'), { wrapper });
+    expect(result.current).toBe(GENERIC_TERMS);
+  });
+
+  it('should fall back to the generic page before the config has loaded', () => {
+    const wrapper = createWrapper(undefined);
+    const { result } = renderHook(() => useLocalizedLink('privacy_policy'), { wrapper });
+    expect(result.current).toBe(GENERIC_PRIVACY_POLICY);
+  });
+
+  it('should never return an empty href', () => {
+    const wrapper = createWrapper({ privacy_policy: {} });
+    const { result } = renderHook(() => useLocalizedLink('privacy_policy'), { wrapper });
+    expect(result.current).toBeTruthy();
   });
 });

--- a/src/Components/Config/configHook.tsx
+++ b/src/Components/Config/configHook.tsx
@@ -7,6 +7,11 @@ import { FormattedMessage } from 'react-intl';
 import { Language } from '../../Assets/languageOptions';
 import { Icon } from '../Icon/Icon';
 
+const FALLBACK_FOOTER_URLS = {
+  privacy_policy: 'https://www.myfriendben.org/privacy-policy/',
+  consent_to_contact: 'https://www.myfriendben.org/terms-and-conditions/',
+};
+
 export const OPTION_CARD_ICON_MAP: Record<string, string> = {
   // Health Insurance
   None: 'ban',
@@ -40,7 +45,6 @@ export const OPTION_CARD_ICON_MAP: Record<string, string> = {
   Aging: 'tree-deciduous',
   Youth_development: 'shapes',
 };
-
 
 type Item = {
   _label: string;
@@ -127,7 +131,7 @@ function transformConfigData(configData: ConfigApiResponse[]): Config {
           if (key in mergedFlags && mergedFlags[key] !== value) {
             console.warn(
               `Feature flag '${key}' is defined in multiple config items with different values. ` +
-              `Previous: ${mergedFlags[key]}, Current: ${value}. Using current value from config '${item.name}'.`
+                `Previous: ${mergedFlags[key]}, Current: ${value}. Using current value from config '${item.name}'.`,
             );
           }
         }
@@ -247,19 +251,13 @@ export function useFeatureFlag(flag: string): boolean {
   return config?._feature_flags?.[flag] ?? false;
 }
 
-export function useLocalizedLink(configKey: 'privacy_policy' | 'consent_to_contact') {
+export function useLocalizedLink(configKey: keyof typeof FALLBACK_FOOTER_URLS) {
   const { locale } = useContext(Context);
   const links = useConfig<Partial<Record<Language, string>>>(configKey, {});
-
-  // Fallback URLs if not found in config
-  const fallbackUrls = {
-    privacy_policy: 'https://www.myfriendben.org/privacy-policy/',
-    consent_to_contact: 'https://www.myfriendben.org/terms-and-conditions/',
-  };
 
   // Empty strings have to fall through, not just null/undefined: a white label that never
   // overrode these keys sends {"en-us": ""}, and `??` would return that empty string and
   // render a link with an empty href. These links carry legal copy, so falling back to the
   // generic MyFriendBen page is always better than pointing nowhere.
-  return links[locale] || links['en-us'] || fallbackUrls[configKey];
+  return links[locale] || links['en-us'] || FALLBACK_FOOTER_URLS[configKey];
 }

--- a/src/Components/Config/configHook.tsx
+++ b/src/Components/Config/configHook.tsx
@@ -257,5 +257,9 @@ export function useLocalizedLink(configKey: 'privacy_policy' | 'consent_to_conta
     consent_to_contact: 'https://www.myfriendben.org/terms-and-conditions/',
   };
 
-  return links[locale] ?? links['en-us'] ?? fallbackUrls[configKey] ?? '';
+  // Empty strings have to fall through, not just null/undefined: a white label that never
+  // overrode these keys sends {"en-us": ""}, and `??` would return that empty string and
+  // render a link with an empty href. These links carry legal copy, so falling back to the
+  // generic MyFriendBen page is always better than pointing nowhere.
+  return links[locale] || links['en-us'] || fallbackUrls[configKey];
 }


### PR DESCRIPTION
## Context & Motivation

`useLocalizedLink` already defines generic MyFriendBen fallback URLs for `privacy_policy` and `consent_to_contact`, but chained them with `??`:

```ts
return links[locale] ?? links['en-us'] ?? fallbackUrls[configKey] ?? '';
```

`??` only falls through on `null`/`undefined`. A white label whose config sends `{"en-us": ""}` — KS, MO, and WA all do — hits the empty string, which is neither, so the hook returns `""` and the fallback never fires. Every consumer then renders a link with an empty `href`: the footers (`Footer`, `PoweredByFooter`, `LancFooter`, `CclaFooter`, `TwoOneOneFooterCO/NC`, `NCHispanicFederationFooter`), the step-1 `Disclaimer`, and `SignUp`. These are the privacy policy and terms links.

`_default` never showed the bug for the opposite reason: it has no such config rows at all, so `undefined` correctly reached the fallback. Supplying an empty string is what defeated it.

- Fixes [MFB-1603](https://linear.app/myfriendben/issue/MFB-1603/privacy-policy-and-terms-footer-links-are-empty-for-mo-ks-and-wa)
- Related PR: MyFriendBen/benefits-api#1689 (populates the three white label configs — the two together are the full fix)

## Changes Made

- **`configHook.tsx`** — `??` → `||` in `useLocalizedLink`, so an empty string falls through to the generic page. Dropped the trailing `?? ''`, which was unreachable given the typed `configKey`.
- **`configHook.test.tsx`** — new `useLocalizedLink` describe block (7 cases). The hook previously had no coverage: locale match, en-us fallback for untranslated locales, empty string at the locale key, empty string at `en-us`, absent config key, config not yet loaded, and a never-returns-empty assertion.

Why both this and the backend config fix: the config change is the correct data fix, but it is what a future white label will forget again. This makes the hook structurally incapable of emitting an empty `href`, and it takes effect without waiting on an `add_config` run.

## Testing

- **Migrations to run:** none
- **Configuration updates needed:** none. This change deliberately does not depend on the backend config import — it fixes all three states on deploy regardless of what the `Configuration` rows contain.
- **Environment variables/settings to add:** none
- **Manual testing steps:**
  1. `CI=true npx react-scripts test --env=jsdom --testPathPattern configHook` — 22 passed locally
  2. To confirm the tests are real regression coverage: revert the `||` back to `??` and re-run. Exactly the two empty-string cases fail; the other five pass.
  3. Against a backend where ks/mo/wa still return `{"en-us": ""}`, load `/ks/step-1` and check the footer Privacy / Terms links plus the disclaimer consent links — they should resolve to `myfriendben.org` instead of an empty `href`.

## Deployment

- **Post-deployment scripts needed:** none
- **Production config updates:** none for this PR. The companion benefits-api PR needs `add_config --all`, which the deploy workflows run automatically.
- **Admin updates needed:** none
- **Notify team/users of:** nothing user-facing beyond the links starting to work. Worth coordinating the merge order note below with whoever ships the api PR.

## Notes for Reviewers

- **The `||` is intentional, not a lint-style preference.** `??` is usually the safer default, and a reviewer may reasonably flag this as a regression toward truthiness. Here the falsy value we must catch *is* `""` — the whole bug. I left a comment at the call site saying so, so it does not get "corrected" back later.
- **Known limitations:**
  - `||` also treats a hypothetical `0`/`NaN` as absent, which cannot occur — the values are typed `string`.
  - This is defense in depth, not a substitute for the config fix. Without the api PR, ks/mo/wa point at the generic MyFriendBen pages via the hardcoded fallback rather than through their own config, which is invisible to anyone auditing the white label files.
- **Future considerations:** the two fallback URLs are hardcoded in the hook and duplicated in `base.py` on the backend. That is fine as a last-resort default, but if MyFriendBen ever changes those URLs, both places need updating.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localized links to correctly fall back when configured URLs are empty or unavailable.
  * Added reliable fallback behavior for locale-specific links, including `en-us`, privacy, and terms pages.
  * Prevented links from rendering with empty destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->