### PR TITLE
MFB-1622: KS/MO additional resources: add the Transportation immediate-need tile

### DIFF
--- a/src/Assets/updateFormData.tsx
+++ b/src/Assets/updateFormData.tsx
@@ -44,6 +44,7 @@ export function useUpdateFormData() {
         agingResources: response.needs_aging_resources ?? false,
         homelessServices: response.needs_homeless_services ?? false,
         freeLowCostMedicalCare: response.needs_free_low_cost_medical_care ?? false,
+        transportation: response.needs_transportation ?? false,
       },
       signUpInfo: {
         email: '',

--- a/src/Assets/updateScreen.ts
+++ b/src/Assets/updateScreen.ts
@@ -58,6 +58,7 @@ const getScreensBody = (formData: FormData, languageCode: Language, whiteLabel: 
     needs_aging_resources: formData.acuteHHConditions.agingResources ?? null,
     needs_homeless_services: formData.acuteHHConditions.homelessServices ?? null,
     needs_free_low_cost_medical_care: formData.acuteHHConditions.freeLowCostMedicalCare ?? null,
+    needs_transportation: formData.acuteHHConditions.transportation ?? null,
     utm_id: formData.utm?.id ?? null,
     utm_source: formData.utm?.source ?? null,
     utm_medium: formData.utm?.medium ?? null,

--- a/src/Components/Config/configHook.tsx
+++ b/src/Components/Config/configHook.tsx
@@ -36,6 +36,7 @@ export const OPTION_CARD_ICON_MAP: Record<string, string> = {
   Health_care: 'hospital',
   Legal_services: 'scale',
   Savings: 'piggy-bank',
+  Transportation: 'bus-front',
   Military: 'shield',
   Aging: 'tree-deciduous',
   Youth_development: 'shapes',

--- a/src/Types/ApiFormData.ts
+++ b/src/Types/ApiFormData.ts
@@ -179,6 +179,7 @@ export type ApiFormData = {
   needs_aging_resources: boolean | null;
   needs_homeless_services: boolean | null;
   needs_free_low_cost_medical_care: boolean | null;
+  needs_transportation: boolean | null;
   utm_id: string | null;
   utm_source: string | null;
   utm_medium: string | null;


### PR DESCRIPTION
## Context & Motivation

Kansas and Missouri had no additional resources ("urgent needs") in the screener. Landing the vetted KS/MO set required three new immediate-need tiles, one of which — **Transportation** — is a brand-new category with no existing `Screen.needs_*` field, so it needs frontend plumbing to be selectable at all.

Without this PR the backend field exists but the checkbox is never rendered or submitted, and the five transportation resources (MO Rides, KS Rides, Wichita Transit Half-Fare, RideKC, Metro Transit reduced fares) can never be shown.

**Linear tickets**

- MFB-1622 — Implement Additional Resources for KS
- MFB-1621 — Implement Additional Resources for MO
- MFB-1338 — + Resource: [IL] Add WorkNet DuPage to IL resources
- MFB-1416 — + Resource: ID Help for the Unhoused resource to WA screener
- MFB-1421 — Discovery: Additional Resources for KS/MO (source research, Done)

Companion backend PR: MyFriendBen/benefits-api#1692 — **must merge and deploy first**, since it adds the `needs_transportation` field this PR posts to.

## Changes Made

Four one-line additions, following the same shape as the NC tiles in #2171:

- `src/Components/Config/configHook.tsx` — `Transportation: 'bus-front'` in `OPTION_CARD_ICON_MAP`, so the tile renders an icon on the immediate-needs step
- `src/Assets/updateScreen.ts` — sends `needs_transportation` from `acuteHHConditions.transportation`
- `src/Assets/updateFormData.tsx` — rehydrates `acuteHHConditions.transportation` from the API response
- `src/Types/ApiFormData.ts` — `needs_transportation: boolean | null`

No change was needed for `AcuteHHConditions`, which is an index signature (`{ [key: string]: boolean }`).

The other two tiles the backend adds (`freeLowCostMedicalCare` for ks/mo and `savings` for ks/mo) need **no frontend change** — `Health_care` and `Savings` are already in `OPTION_CARD_ICON_MAP` and both `Screen.needs_*` fields and `acuteHHConditions` keys already exist, since NC and CO use them.

`transportation` was already half-wired: `src/Components/Results/helpers.ts` maps `transportation` → `bus-front` in `ICON_NAME_MAP` for the results-page section header. That is a different map from the tile icons in `configHook.tsx`, which is what was missing.

## Testing

- **Migrations to run:** none (frontend).
- **Configuration updates needed:** none here — the tile itself comes from the backend's `acute_condition_options`, so the API must be running the companion branch with `python manage.py add_config ks mo il` applied.
- **Environment variables/settings to add:** none.

**Manual testing steps**

1. Point the frontend at an API running benefits-api#1692 with its migration, `add_config`, and resource import applied.
2. Start a KS screener and reach the immediate-needs step. Confirm 12 tiles, including **Transportation** with a bus icon.
3. Check Transportation, continue, and confirm it persists — go back a step and confirm the box is still checked (exercises `updateFormData`).
4. Finish the screener and confirm resources appear under a Transportation heading (KS Rides statewide; RideKC and Wichita Transit are county-scoped).
5. Repeat for MO (MO Rides, RideKC, Metro Transit) and IL (Metro Transit, St. Clair or Madison county zip only).
6. Confirm CO, MA, NC, TX and WA immediate-needs steps are unchanged — none of them get a Transportation tile.

**Automated**

```bash
CI=true npx react-scripts test --env=jsdom --watchAll=false
```

Tests use `react-scripts` (jest), not vitest — running these files under vitest fails with `jest is not defined`.

## Deployment

- **Post-deployment scripts needed:** none for the frontend.
- **Production config updates:** none.
- **Admin updates needed:** none.
- **Ordering:** deploy the backend first. This PR alone is inert — it posts a field the API would reject as unknown until the migration lands. The reverse order is also safe but leaves the tile unselectable.
- **Notify team/users of:** KS and MO immediate-needs steps go from 9 tiles to 12, IL from 11 to 12. Worth flagging to anyone doing partner demos.

## Notes for Reviewers

**Known limitations**

- **IL's Transportation tile currently backs a single resource** (Metro Transit reduced fares, St. Clair + Madison counties), so Cook County users will see the tile with nothing behind it. There is precedent — NC's `homelessServices` and `freeLowCostMedicalCare` tiles have no resources today.
- `npx tsc --noEmit` reports 29 pre-existing errors on this branch. That count is **identical on `main`** — none are introduced here.
- Prettier wanted to reformat two unrelated pre-existing spots in `configHook.tsx` (a stray blank line and a nested template-literal indent). Both were reverted to keep this diff to the single intended line.

**Future considerations**

- **Dollar For** (MFB-1253) is intentionally excluded from this batch. It is the only resource in a "Medical Expenses & Debt" category and is meant for all eight white labels, so it would force a `base.py` tile change plus another round of this same four-file frontend plumbing. Shipping separately.
- If Transportation later goes to all eight white labels, no further frontend work is needed — only `acute_condition_options` entries per white label on the backend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transportation needs to household condition information.
  * Transportation selections are now saved and restored when completing forms.
  * Added a bus icon for transportation-related options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->