### PR TITLE
MFB-1253: Add the Medical Expenses & Debt immediate-need tile

### DIFF
--- a/src/Assets/updateFormData.tsx
+++ b/src/Assets/updateFormData.tsx
@@ -45,6 +45,7 @@ export function useUpdateFormData() {
         homelessServices: response.needs_homeless_services ?? false,
         freeLowCostMedicalCare: response.needs_free_low_cost_medical_care ?? false,
         transportation: response.needs_transportation ?? false,
+        medicalExpensesAndDebt: response.needs_medical_expenses_and_debt ?? false,
       },
       signUpInfo: {
         email: '',

--- a/src/Assets/updateScreen.ts
+++ b/src/Assets/updateScreen.ts
@@ -59,6 +59,7 @@ const getScreensBody = (formData: FormData, languageCode: Language, whiteLabel: 
     needs_homeless_services: formData.acuteHHConditions.homelessServices ?? null,
     needs_free_low_cost_medical_care: formData.acuteHHConditions.freeLowCostMedicalCare ?? null,
     needs_transportation: formData.acuteHHConditions.transportation ?? null,
+    needs_medical_expenses_and_debt: formData.acuteHHConditions.medicalExpensesAndDebt ?? null,
     utm_id: formData.utm?.id ?? null,
     utm_source: formData.utm?.source ?? null,
     utm_medium: formData.utm?.medium ?? null,

--- a/src/Components/Config/configHook.tsx
+++ b/src/Components/Config/configHook.tsx
@@ -42,6 +42,7 @@ export const OPTION_CARD_ICON_MAP: Record<string, string> = {
   Legal_services: 'scale',
   Savings: 'piggy-bank',
   Transportation: 'bus-front',
+  Medical_expenses_and_debt: 'heart-plus',
   Military: 'shield',
   Aging: 'tree-deciduous',
   Youth_development: 'shapes',

--- a/src/Components/Results/helpers.ts
+++ b/src/Components/Results/helpers.ts
@@ -28,6 +28,7 @@ export const ICON_NAME_MAP: Record<string, string> = {
   light_bulb: 'lightbulb',
   lightning: 'zap',
   managing_housing: 'house',
+  medical_expenses_and_debt: 'heart-plus',
   savings: 'piggy-bank',
   talk: 'message-circle',
   tax_credit: 'banknote',

--- a/src/Types/ApiFormData.ts
+++ b/src/Types/ApiFormData.ts
@@ -180,6 +180,7 @@ export type ApiFormData = {
   needs_homeless_services: boolean | null;
   needs_free_low_cost_medical_care: boolean | null;
   needs_transportation: boolean | null;
+  needs_medical_expenses_and_debt: boolean | null;
   utm_id: string | null;
   utm_source: string | null;
   utm_medium: string | null;


### PR DESCRIPTION
## Context & Motivation

Dollar For helps patients get hospital bills reduced or cancelled through charity-care programs. Adding it requires a new **Medical Expenses & Debt** immediate-need category, which is a brand-new tile with no existing `Screen.needs_*` field — so it needs frontend plumbing to be selectable at all.

Without this PR the backend field exists but the checkbox is never rendered or submitted, and the 8 Dollar For records (one per white label) can never be shown.

**Linear ticket**

- MFB-1253 — + Resource: Dollar For as a medical debt resource

**Related PRs**

- Companion backend PR: MyFriendBen/benefits-api#1699 — **must merge and deploy first**, since it adds the `needs_medical_expenses_and_debt` field this PR posts to
- MyFriendBen/benefits-calculator#2181 — the KS/MO additional-resources batch this was split out of

## Changes Made

Five one-line additions, following the same shape as the Transportation tile in #2181 and the NC tiles in #2171:

- `src/Components/Config/configHook.tsx` — `Medical_expenses_and_debt: 'heart-plus'` in `OPTION_CARD_ICON_MAP`, for the tile on the immediate-needs step
- `src/Components/Results/helpers.ts` — `medical_expenses_and_debt: 'heart-plus'` in `ICON_NAME_MAP`, for the section heading on the results page
- `src/Assets/updateScreen.ts` — sends `needs_medical_expenses_and_debt` from `acuteHHConditions.medicalExpensesAndDebt`
- `src/Assets/updateFormData.tsx` — rehydrates `acuteHHConditions.medicalExpensesAndDebt` from the API response
- `src/Types/ApiFormData.ts` — `needs_medical_expenses_and_debt: boolean | null`

Two icon maps are needed because they serve different surfaces and are keyed differently: `OPTION_CARD_ICON_MAP` is keyed by the config's `_icon` value (`Medical_expenses_and_debt`) for the selection tile, while `ICON_NAME_MAP` is keyed by the `UrgentNeedType.icon` name the API returns (`medical_expenses_and_debt`) for the results heading.

No change was needed for `AcuteHHConditions`, which is an index signature (`{ [key: string]: boolean }`).

**No special styling.** The icon renders through the existing `<Icon name={...} className="option-card-lucide-icon" />` path used by every other tile, so it inherits identical CSS. Nothing bespoke was added.

## Testing

- **Migrations to run:** none (frontend).
- **Configuration updates needed:** none here — the tile itself comes from the backend's `acute_condition_options`, so the API must be running the companion branch with `python manage.py add_config --all` applied.
- **Environment variables/settings to add:** none.

**Manual testing steps**

1. Point the frontend at an API running benefits-api#1699 with its migration, `add_config --all`, and resource import applied.
2. Start a screener in any white label and reach the immediate-needs step. Confirm a **Medical Expenses & Debt** tile rendering the heart-plus icon, styled identically to its neighbours.
3. Check it, continue, then navigate back and confirm it is still checked (exercises `updateFormData`).
4. Finish the screener and confirm **Dollar For** appears under a "Medical Expenses & Debt" heading, also with the heart-plus icon, linking to `https://dollarfor.org/`.
5. Spot-check more than one white label — the tile is present in all 8 (co, il, ks, ma, mo, nc, tx, wa).
6. Confirm the CESN energy screener is unchanged and shows no immediate-needs tiles.

**Automated**

```bash
CI=true npx react-scripts test --env=jsdom --watchAll=false
```

`src/Components/Icon/iconMaps.test.tsx` is the relevant guard — it asserts every value in both icon maps resolves to a real Lucide icon, so a typo in either new entry fails the build rather than silently rendering nothing. Both new entries are covered:

```
✓ OPTION_CARD_ICON_MAP["Medical_expenses_and_debt"] = "heart-plus" renders a Lucide svg
✓ ICON_NAME_MAP["medical_expenses_and_debt"] = "heart-plus" renders a Lucide svg
```

Tests use `react-scripts` (jest), not vitest — running these files under vitest fails with `jest is not defined`.

## Deployment

- **Post-deployment scripts needed:** none for the frontend.
- **Production config updates:** none.
- **Admin updates needed:** none.
- **Ordering:** deploy the backend first. If this ships ahead of the backend the failure is **silent, not loud**: DRF ignores unknown keys, so `needs_medical_expenses_and_debt` is dropped with no validation error and the user's selection is lost rather than rejected. Backend-first is safe in both directions — the column is `null=True, default=False`, and an older frontend that omits the key still validates. Verified against `ScreenSerializer`: the field is in `fields`, not `read_only_fields`, and round-trips (accepted on input, persisted, returned on output).
- **Notify team/users of:** every white label's immediate-needs step gains a tile — co 10→11, wa 10→11, nc 11→12, tx 11→12, il 12→13, ks 12→13, ma 12→13, mo 12→13. This is the first change in this series to touch CO, MA, NC and TX, so it is worth flagging to anyone doing partner demos in those states.

## Notes for Reviewers

**Known limitations**

- **One resource behind a new tile in all 8 states.** Users will see a Medical Expenses & Debt tile whose only result is Dollar For. Intentional, since the resource is national, but the category is thin until more medical-debt resources are added. There is precedent: NC's `homelessServices` tile has no resources at all today.
- `npx tsc --noEmit` reports 29 pre-existing errors on this branch. That count is **identical on `main`** — none are introduced here.
- `heart-plus` was confirmed present in the installed `lucide-react@1.22.0` (`HeartPlus`) before being wired up; the `Icon` component converts kebab-case to PascalCase and warns to console for unknown names.

**Future considerations**

- Any future medical-debt resource now drops in as a backend config file only — no further frontend work needed.
- The two parallel icon maps (`OPTION_CARD_ICON_MAP` and `ICON_NAME_MAP`) both need updating for every new category and are easy to half-complete; the guard test catches typos but not omissions. Worth considering a merge or a cross-check test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording whether medical expenses and debt are a household need.
  * This information is now preserved when forms are loaded and submitted.
  * Added a heart-plus icon to represent medical expenses and debt in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
