### PR TITLE
MFB-824: add Immediate Help tab to results page

### DIFF
--- a/src/Assets/analytics/events.ts
+++ b/src/Assets/analytics/events.ts
@@ -116,17 +116,12 @@ export interface ScreenerEventMap {
   // 'income-frequency') and tagged with the hosting step via StepContext. Not the
   // results-page "More Help / 211" CTA below.
   screener_help_click: StepContext & { help_topic: string };
-  // "User asked for more help" — surface-agnostic; `location` names the surface, so the
-  // event survives UI moves. Kept separate from screener_help_click so it doesn't pollute
-  // the inline-tooltip confusion metric. Current emitters:
-  //   'immediate_help_tab' — the Immediate Help results tab (Tabs.tsx)
-  //   'results'            — the bottom "More Help / 211" CTA, now CESN-only, since CESN
-  //                          renders no tab bar (211Button.tsx)
-  // Redundant with screener_results_tab_click{tab_name:'immediate_help'} by design, to keep
-  // existing GA4 reporting continuous. Retire this emitter once tab_name is confirmed
-  // flowing (~2 reporting cycles) so the duplication doesn't become permanent.
+  // Fired from the Immediate Help tab (location: 'immediate_help_tab') and CESN's
+  // bottom button (location: 'results'). Deliberately kept alongside
+  // screener_results_tab_click for GA4 continuity — retire once tab_name is confirmed flowing.
   screener_get_help_click: { location?: string };
-  // "Other Resources Near You" (Immediate Help tab) "Visit Website" link click.
+  // "Visit Website" click on Other Resources Near You — fires from the Immediate Help
+  // tab or CESN's standalone more-help page.
   // `resource_name` is the config `label` (a plain string, PII-free);
   // `resource_index` is the item's ordinal on the page.
   screener_more_help_resource_click: { resource_name?: string; resource_index?: number; url?: string };

--- a/src/Assets/analytics/events.ts
+++ b/src/Assets/analytics/events.ts
@@ -116,10 +116,17 @@ export interface ScreenerEventMap {
   // 'income-frequency') and tagged with the hosting step via StepContext. Not the
   // results-page "More Help / 211" CTA below.
   screener_help_click: StepContext & { help_topic: string };
-  // Results-page "More Help / 211" CTA — kept separate from screener_help_click so
-  // it doesn't pollute the inline-tooltip confusion metric.
+  // "User asked for more help" — surface-agnostic; `location` names the surface, so the
+  // event survives UI moves. Kept separate from screener_help_click so it doesn't pollute
+  // the inline-tooltip confusion metric. Current emitters:
+  //   'immediate_help_tab' — the Immediate Help results tab (Tabs.tsx)
+  //   'results'            — the bottom "More Help / 211" CTA, now CESN-only, since CESN
+  //                          renders no tab bar (211Button.tsx)
+  // Redundant with screener_results_tab_click{tab_name:'immediate_help'} by design, to keep
+  // existing GA4 reporting continuous. Retire this emitter once tab_name is confirmed
+  // flowing (~2 reporting cycles) so the duplication doesn't become permanent.
   screener_get_help_click: { location?: string };
-  // "Other Resources Near You" (more-help page) "Visit Website" link click.
+  // "Other Resources Near You" (Immediate Help tab) "Visit Website" link click.
   // `resource_name` is the config `label` (a plain string, PII-free);
   // `resource_index` is the item's ordinal on the page.
   screener_more_help_resource_click: { resource_name?: string; resource_index?: number; url?: string };

--- a/src/Components/MoreHelp/MoreHelp.css
+++ b/src/Components/MoreHelp/MoreHelp.css
@@ -2,9 +2,9 @@
   padding: 1rem;
 }
 
-/* Inside the Immediate Help tab the card body already supplies `0 1rem 1.5rem`, so the
-   horizontal padding is dropped to avoid doubled side gutters. Scoped to that parent so
-   the standalone page CESN still uses (it has no tab bar) keeps its original spacing. */
+/* `.results-card-body` already adds 1rem side padding, so drop it here to avoid
+   doubling. Scoped to that ancestor so CESN's standalone page (no such wrapper)
+   keeps its original padding. */
 .results-card-body .more-help-container {
   padding: 1rem 0;
 }
@@ -23,10 +23,8 @@
 
 .more-help-header {
   color: var(--primary-color);
-  /* Renders as <h2> inside the Immediate Help tab (correct heading order under the tab
-     bar) or <h1> on CESN's standalone page (its only top-level heading — see MoreHelp's
-     `isStandalonePage` prop). Font metrics pinned to the old, always-<h1> defaults so
-     neither case has a visual diff from before this component's heading became variable. */
+  /* Tag varies: <h2> in the tab, <h1> standalone (see isStandalonePage). Pinned to the
+     old always-<h1> metrics so neither case shows a visual diff. */
   font-size: 2em;
   margin: 0.67em 0;
 }

--- a/src/Components/MoreHelp/MoreHelp.css
+++ b/src/Components/MoreHelp/MoreHelp.css
@@ -2,6 +2,13 @@
   padding: 1rem;
 }
 
+/* Inside the Immediate Help tab the card body already supplies `0 1rem 1.5rem`, so the
+   horizontal padding is dropped to avoid doubled side gutters. Scoped to that parent so
+   the standalone page CESN still uses (it has no tab bar) keeps its original spacing. */
+.results-card-body .more-help-container {
+  padding: 1rem 0;
+}
+
 .back-button {
   padding: 0.25rem 0.75rem;
   margin-bottom: 1rem;
@@ -16,6 +23,12 @@
 
 .more-help-header {
   color: var(--primary-color);
+  /* Renders as <h2> inside the Immediate Help tab (correct heading order under the tab
+     bar) or <h1> on CESN's standalone page (its only top-level heading — see MoreHelp's
+     `isStandalonePage` prop). Font metrics pinned to the old, always-<h1> defaults so
+     neither case has a visual diff from before this component's heading became variable. */
+  font-size: 2em;
+  margin: 0.67em 0;
 }
 
 .resource-card-article {
@@ -27,6 +40,12 @@
   color: var(--primary-color);
   font-size: 1rem;
   white-space: pre-line;
+}
+
+/* Was an <h1>; demoted to <h3>. font-size is already pinned above, so only the default
+   margin needed restoring to keep the rendering identical. */
+.resource-header {
+  margin: 0.67em 0;
 }
 
 .resource-desc {

--- a/src/Components/MoreHelp/MoreHelp.test.tsx
+++ b/src/Components/MoreHelp/MoreHelp.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { MemoryRouter } from 'react-router-dom';
+import MoreHelp from './MoreHelp';
+
+jest.mock('../Config/configHook', () => ({
+  useConfig: () => ({ moreHelpOptions: [] }),
+}));
+
+const renderWithProviders = (isStandalonePage?: boolean) => {
+  return render(
+    <MemoryRouter>
+      <IntlProvider locale="en" defaultLocale="en">
+        <MoreHelp isStandalonePage={isStandalonePage} />
+      </IntlProvider>
+    </MemoryRouter>,
+  );
+};
+
+describe('MoreHelp', () => {
+  // Nested under the Immediate Help tab (isStandalonePage unset), the results page
+  // supplies its own top-level heading, so "Other Resources Near You" must not also be
+  // an <h1> — that would give the page two level-1 headings.
+  it('renders the header as an h2 when nested in the tab (default)', () => {
+    renderWithProviders();
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Other Resources Near You' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+  });
+
+  // CESN's standalone /results/more-help page (see Results.tsx) has no tab bar and no
+  // other heading, so this is the page's only top-level heading and must be an <h1>.
+  it('renders the header as an h1 on the standalone page', () => {
+    renderWithProviders(true);
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Other Resources Near You' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 2 })).not.toBeInTheDocument();
+  });
+});

--- a/src/Components/MoreHelp/MoreHelp.test.tsx
+++ b/src/Components/MoreHelp/MoreHelp.test.tsx
@@ -18,9 +18,8 @@ const renderWithProviders = (isStandalonePage?: boolean) => {
 };
 
 describe('MoreHelp', () => {
-  // Nested under the Immediate Help tab (isStandalonePage unset), the results page
-  // supplies its own top-level heading, so "Other Resources Near You" must not also be
-  // an <h1> — that would give the page two level-1 headings.
+  // Nested in the tab (isStandalonePage unset), the results page already has its own
+  // h1, so this must not be a second one.
   it('renders the header as an h2 when nested in the tab (default)', () => {
     renderWithProviders();
 
@@ -28,8 +27,8 @@ describe('MoreHelp', () => {
     expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
   });
 
-  // CESN's standalone /results/more-help page (see Results.tsx) has no tab bar and no
-  // other heading, so this is the page's only top-level heading and must be an <h1>.
+  // CESN's standalone page (see Results.tsx) has no other heading, so this one must
+  // be the h1.
   it('renders the header as an h1 on the standalone page', () => {
     renderWithProviders(true);
 

--- a/src/Components/MoreHelp/MoreHelp.tsx
+++ b/src/Components/MoreHelp/MoreHelp.tsx
@@ -26,8 +26,20 @@ export const resourceNameFromConfig = (resource: Resource): string | undefined =
   return undefined;
 };
 
-const MoreHelp = () => {
-  const { moreHelpOptions } = useConfig<{ moreHelpOptions: Resource[] }>('more_help_options');
+type MoreHelpProps = {
+  // True only on CESN's standalone page (see Results.tsx), which has no other top-level
+  // heading. Everywhere else this renders inside the Immediate Help tab, nested under
+  // the results page's own heading structure, so "Other Resources Near You" is an h2.
+  isStandalonePage?: boolean;
+};
+
+const MoreHelp = ({ isStandalonePage = false }: MoreHelpProps) => {
+  // Defaulted rather than left to throw: this now renders inside the main results
+  // route instead of a standalone page, and there is no ErrorBoundary in the app, so
+  // a missing config key would blank the whole page rather than just this tab.
+  const { moreHelpOptions } = useConfig<{ moreHelpOptions: Resource[] }>('more_help_options', {
+    moreHelpOptions: [],
+  });
   const resources: Resource[] = moreHelpOptions;
   const track = useTrackEvent();
 
@@ -35,9 +47,9 @@ const MoreHelp = () => {
     return resources.map((resource, index) => {
       return (
         <article key={index} className="resource-card-article">
-          <h1 className="resource-header" key={index}>
+          <h3 className="resource-header" key={index}>
             {resource.name}
-          </h1>
+          </h3>
           {resource.description && <p className="resource-desc">{resource.description}</p>}
           {resource.phone && <p className="resource-phone">{resource.phone}</p>}
           <div className="resource-link-container">
@@ -69,9 +81,15 @@ const MoreHelp = () => {
   return (
     <div className="more-help-container">
       <div className="underline-header-container">
-        <h1 className="more-help-header">
-          <FormattedMessage id="moreHelp.header" defaultMessage="Other Resources Near You" />
-        </h1>
+        {isStandalonePage ? (
+          <h1 className="more-help-header">
+            <FormattedMessage id="moreHelp.header" defaultMessage="Other Resources Near You" />
+          </h1>
+        ) : (
+          <h2 className="more-help-header">
+            <FormattedMessage id="moreHelp.header" defaultMessage="Other Resources Near You" />
+          </h2>
+        )}
       </div>
       {displayResources(resources)}
     </div>

--- a/src/Components/MoreHelp/MoreHelp.tsx
+++ b/src/Components/MoreHelp/MoreHelp.tsx
@@ -27,16 +27,14 @@ export const resourceNameFromConfig = (resource: Resource): string | undefined =
 };
 
 type MoreHelpProps = {
-  // True only on CESN's standalone page (see Results.tsx), which has no other top-level
-  // heading. Everywhere else this renders inside the Immediate Help tab, nested under
-  // the results page's own heading structure, so "Other Resources Near You" is an h2.
+  // True only on CESN's standalone page (see Results.tsx) — its only top-level
+  // heading, so it's an h1. Elsewhere (the Immediate Help tab) it's an h2.
   isStandalonePage?: boolean;
 };
 
 const MoreHelp = ({ isStandalonePage = false }: MoreHelpProps) => {
-  // Defaulted rather than left to throw: this now renders inside the main results
-  // route instead of a standalone page, and there is no ErrorBoundary in the app, so
-  // a missing config key would blank the whole page rather than just this tab.
+  // Defaulted, not left to throw: this now lives inside the main results route, and
+  // with no ErrorBoundary in the app, a missing key would blank the whole page, not just this tab.
   const { moreHelpOptions } = useConfig<{ moreHelpOptions: Resource[] }>('more_help_options', {
     moreHelpOptions: [],
   });

--- a/src/Components/Results/Results.css
+++ b/src/Components/Results/Results.css
@@ -63,6 +63,22 @@
   margin: 0;
 }
 
+/* Three-tab-only adjustments. Scoped to [data-tab-count='3'] so the two-tab layout —
+   still rendered for referrers carrying `no_results_more_help` — is byte-identical to
+   before this change. At ~33% width the labels can wrap, so the anchor becomes a
+   centering flex container (Grid items stretch to equal height, and without this a
+   one-line tab would sit top-aligned next to a two-line neighbour). */
+.results-tab-container[data-tab-count='3'] .results-tab a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.results-tab-container[data-tab-count='3'] .results-tab a .results-tab-label {
+  /* Only breaks where a word would otherwise overflow its tab; no hyphens inserted. */
+  overflow-wrap: break-word;
+}
+
 .results-tab a.active {
   background-color: white;
 }
@@ -159,43 +175,6 @@
 
 .results-header {
   height: 7rem;
-}
-
-.results-needs-header-background {
-  background-color: var(--secondary-background-color);
-  padding: 1rem;
-}
-
-.results-needs-header {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  height: 7rem;
-  background-color: var(--primary-color);
-  color: white;
-  text-align: center;
-  line-height: normal;
-  max-width: var(--content-max-width);
-  margin: 0 auto;
-}
-
-.results-needs-header-programs {
-  display: flex;
-  justify-content: center;
-  font-size: xxx-large;
-  font-family: var(--font-heading);
-  font-weight: 700;
-}
-
-.results-needs-header-programs-text {
-  display: flex;
-  width: 8rem;
-  font-size: large;
-  font-family: var(--font-body);
-  font-weight: 400;
-  margin: auto;
-  margin-top: -0.5rem;
-  margin-bottom: 0.5rem;
 }
 
 .result-program-container hr {
@@ -432,6 +411,16 @@
   .results-tab a .results-tab-label {
     font-size: .9rem;
     margin: 0;
+  }
+
+  /* Three tabs share a narrow viewport, so each gets ~33% instead of 50%. Tightened
+     only for that case; the two-tab mobile rendering above is unchanged. */
+  .results-tab-container[data-tab-count='3'] .results-tab a {
+    padding: 0.5rem 0.15rem;
+  }
+
+  .results-tab-container[data-tab-count='3'] .results-tab a .results-tab-label {
+    font-size: max(0.7rem, min(0.9rem, 2.8vw));
   }
 
   .results-tab-container {

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -1,4 +1,4 @@
-import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { ComponentType, createContext, PropsWithChildren, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import ResultsError from './ResultsError/ResultsError';
 import Loading from './Loading/Loading';
 import {
@@ -14,19 +14,20 @@ import { getEligibility } from '../../apiCalls';
 import { Context } from '../Wrapper/Wrapper';
 import { Navigate, useParams, useSearchParams } from 'react-router-dom';
 import { Grid } from '@mui/material';
-import ResultsHeader from './ResultsHeader/ResultsHeader';
+import ResultsHeader, { ResultsSummary } from './ResultsHeader/ResultsHeader';
 import Needs from './Needs/Needs';
 import Programs from './Programs/Programs';
 import ProgramPage from './ProgramPage/ProgramPage';
 import ResultsTabs from './Tabs/Tabs';
+import { ResultsTabId } from './Tabs/buildTabs';
+import BackAndSaveButtons from './BackAndSaveButtons/BackAndSaveButtons';
+import { FormattedMessage } from 'react-intl';
 import { FilterState, createInitialFilterState } from './Filter/citizenshipFilterConfig';
 import dataLayerPush from '../../Assets/analytics';
 import MoreHelpButton from './211Button/211Button';
 import MoreHelp from '../MoreHelp/MoreHelp';
-import BackAndSaveButtons from './BackAndSaveButtons/BackAndSaveButtons';
 import UrgentNeedBanner from './UrgentNeedBanner/UrgentNeedBanner';
 import ExternalApiFailureBanner from './ExternalApiFailureBanner/ExternalApiFailureBanner';
-import { FormattedMessage } from 'react-intl';
 import './Results.css';
 import { OTHER_PAGE_TITLES } from '../../Assets/pageTitleTags';
 import { addAdminToLink } from '../../Assets/adminLink';
@@ -105,10 +106,29 @@ export function useResultsLink(link: string) {
   return addAdminToLink(`/${whiteLabel}/${uuid}/${link}`, isAdminView);
 }
 
+// Referrer-level opt-out for the Immediate Help destination. The backend flag is still
+// called `no_results_more_help` because it originally hid the bottom "More Help" button;
+// the policy ("this referrer does not surface More Help") is unchanged now that the
+// destination is a tab. Read in one place so the `[] as string[]` default — which
+// getReferrer needs to avoid throwing when referrerData is undefined — isn't duplicated.
+export function useImmediateHelpSuppressed() {
+  const { getReferrer } = useContext(Context);
+
+  return getReferrer('uiOptions', [] as string[]).includes('no_results_more_help');
+}
+
+// GA4 tab_name per browsable tab. Types absent here (program detail, energy rebates)
+// are not tabs and are excluded from scroll-depth tracking.
+const SCROLL_DEPTH_TAB_NAMES: Partial<Record<ResultsProps['type'], string>> = {
+  program: 'long_term_benefits',
+  need: 'additional_resources',
+  help: 'immediate_help',
+};
+
 const Results = ({ type }: ResultsProps) => {
-  const { formData, getReferrer, locale } = useContext(Context);
+  const { formData, locale } = useContext(Context);
   const { whiteLabel, uuid, programId, energyCalculatorRebateType } = useParams();
-  const noHelpButton = getReferrer('uiOptions').includes('no_results_more_help');
+  const immediateHelpSuppressed = useImmediateHelpSuppressed();
 
   const [searchParams] = useSearchParams();
   const isAdminView = useMemo(() => searchParams.get('admin') === 'true', [searchParams.get('admin')]);
@@ -219,14 +239,17 @@ const Results = ({ type }: ResultsProps) => {
     );
   }, [apiResults, shownPrograms, track, trackItemList]);
 
-  // Results-page scroll depth, only on the two browsable tabs (program =
-  // long-term benefits, need = additional resources). Each threshold fires once
-  // per tab per screening.
+  // Results-page scroll depth, only on the browsable tabs (program = long-term
+  // benefits, need = additional resources, help = immediate help). Each threshold
+  // fires once per tab per screening.
   const firedScrollDepths = useRef<Set<number>>(new Set());
   useEffect(() => {
-    const tabName = type === 'program' ? 'long_term_benefits' : type === 'need' ? 'additional_resources' : null;
+    // CESN's `help` route is its own standalone page with no tab bar (see the
+    // `isEnergyCalculator` branch below), so it's excluded here the same way program
+    // detail and energy-rebate routes are — those `type`s just aren't in the lookup.
+    const tabName = whiteLabel === 'cesn' && type === 'help' ? null : (SCROLL_DEPTH_TAB_NAMES[type] ?? null);
     if (tabName === null) {
-      return; // program detail / more-help / rebates aren't browsable tabs
+      return; // program detail / rebates / CESN's standalone help page aren't browsable tabs
     }
     firedScrollDepths.current = new Set(); // new tab → reset the once-per-tab guard
 
@@ -248,7 +271,7 @@ const Results = ({ type }: ResultsProps) => {
 
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
-  }, [type, track]);
+  }, [type, track, whiteLabel]);
 
   // "None eligible" needs BOTH result sets resolved, or we'd fire a false
   // negative while rebates are still loading (and the once-guard would prevent
@@ -348,7 +371,16 @@ const Results = ({ type }: ResultsProps) => {
     );
   } else if (apiError) {
     return <ResultsError />;
-  } else if (programId === undefined && type === 'help') {
+  } else if (programId === undefined && type === 'help' && immediateHelpSuppressed) {
+    // Referrers that opted out of More Help must not reach it by URL either, now that no
+    // tab links there for them. This runs before the CESN branch below, so a suppressed
+    // referrer on CESN redirects here rather than landing on CESN's standalone help page.
+    return <Navigate to={addAdminToLink(`/${whiteLabel}/${uuid}/results/benefits`, isAdminView)} replace />;
+  } else if (programId === undefined && type === 'help' && isEnergyCalculator) {
+    // CESN renders no tab bar (see Tabs.tsx), so Immediate Help stays the standalone page
+    // it is today, reached from the More Help button and keeping its drill-down "BACK TO
+    // RESULTS" affordance. Folding CESN into the tabbed layout instead would leave it with
+    // "BACK TO SCREENER" and no tab bar to return to results with.
     return (
       <main className="benefits-form">
         <Grid container>
@@ -359,30 +391,54 @@ const Results = ({ type }: ResultsProps) => {
                 <FormattedMessage id="results.back-to-results-btn" defaultMessage="BACK TO RESULTS" />
               }
             />
-            <MoreHelp />
+            <MoreHelp isStandalonePage />
           </Grid>
         </Grid>
       </main>
     );
-  } else if (programId === undefined && (type === 'program' || type === 'need')) {
+  } else if (programId === undefined && (type === 'program' || type === 'need' || type === 'help')) {
+    // Panel content and the tab that labels it, keyed by results type. Built here inside
+    // the render function — NOT at module scope — because Results.tsx sits in an import
+    // cycle (Results -> Tabs -> Results). A lookup built at module scope would read
+    // Programs/Needs/MoreHelp at module-evaluation time, which can be before those
+    // modules have finished initializing if the cycle is entered from one of them
+    // instead of from here, permanently baking in `undefined` with no ErrorBoundary to
+    // catch the resulting crash. Rendering never happens until the whole module graph
+    // has finished loading, so building it here is race-free. A Record rather than
+    // nested ternaries, so a fourth type is a compile error instead of a silent
+    // fallthrough to the Long-Term Benefits panel.
+    const panels: Record<ResultsTabId, { tabId: string; Content: ComponentType }> = {
+      program: { tabId: 'long-term-benefits-tab', Content: Programs },
+      need: { tabId: 'near-term-benefits-tab', Content: Needs },
+      help: { tabId: 'immediate-help-tab', Content: MoreHelp },
+    };
+    const panel = panels[type];
+
     return (
       <ResultsContextProvider>
         <BenbotWrapper enabled={isBenbotEnabled}>
           <main>
-            <ResultsHeader type={type} />
+            <ResultsHeader />
             <div className="results-card-wrapper">
-              <ResultsTabs />
-              <div id="results-tabpanel" role="tabpanel" aria-labelledby={type === 'program' ? 'long-term-benefits-tab' : 'near-term-benefits-tab'} className="benefits-form results-card-body">
+              <ResultsTabs activeTab={type} />
+              <div id="results-tabpanel" role="tabpanel" aria-labelledby={panel.tabId} className="benefits-form results-card-body">
+                {/* Inside the panel, not above it: the summary is per-tab content, so it
+                    should be reachable when a screen reader moves into the active panel. */}
+                <ResultsSummary type={type} />
                 {type === 'program' && <ExternalApiFailureBanner />}
                 {type === 'program' && <UrgentNeedBanner />}
                 <Grid container sx={{ pt: '1rem' }}>
                   <Grid item xs={12}>
-                    {type === 'need' ? <Needs /> : <Programs />}
+                    <panel.Content />
                   </Grid>
                 </Grid>
-                {!noHelpButton && <MoreHelpButton />}
-                <NPSWidget uuid={uuid} />
-                <ShareModalAutoPopup />
+                {/* CESN renders no tab bar (see Tabs.tsx), so this button remains its only
+                    entry point to the Immediate Help resources. */}
+                {isEnergyCalculator && !immediateHelpSuppressed && <MoreHelpButton />}
+                {/* Both fire impression events on a timer, so they stay off the help tab to
+                    avoid inflating impressions and diluting the NPS response denominator. */}
+                {type !== 'help' && <NPSWidget uuid={uuid} />}
+                {type !== 'help' && <ShareModalAutoPopup />}
               </div>
             </div>
           </main>

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -106,11 +106,9 @@ export function useResultsLink(link: string) {
   return addAdminToLink(`/${whiteLabel}/${uuid}/${link}`, isAdminView);
 }
 
-// Referrer-level opt-out for the Immediate Help destination. The backend flag is still
-// called `no_results_more_help` because it originally hid the bottom "More Help" button;
-// the policy ("this referrer does not surface More Help") is unchanged now that the
-// destination is a tab. Read in one place so the `[] as string[]` default — which
-// getReferrer needs to avoid throwing when referrerData is undefined — isn't duplicated.
+// Referrer opt-out for Immediate Help. Flag is still named `no_results_more_help`
+// (predates the tab; policy unchanged). Centralizes the `[] as string[]` default
+// getReferrer needs to avoid throwing when referrerData is undefined.
 export function useImmediateHelpSuppressed() {
   const { getReferrer } = useContext(Context);
 
@@ -239,14 +237,11 @@ const Results = ({ type }: ResultsProps) => {
     );
   }, [apiResults, shownPrograms, track, trackItemList]);
 
-  // Results-page scroll depth, only on the browsable tabs (program = long-term
-  // benefits, need = additional resources, help = immediate help). Each threshold
-  // fires once per tab per screening.
+  // Results-page scroll depth, browsable tabs only. Each threshold fires once per tab per screening.
   const firedScrollDepths = useRef<Set<number>>(new Set());
   useEffect(() => {
-    // CESN's `help` route is its own standalone page with no tab bar (see the
-    // `isEnergyCalculator` branch below), so it's excluded here the same way program
-    // detail and energy-rebate routes are — those `type`s just aren't in the lookup.
+    // CESN's `help` route is a standalone page with no tab bar (see `isEnergyCalculator`
+    // below) — exclude it here even though `help` is otherwise in the lookup.
     const tabName = whiteLabel === 'cesn' && type === 'help' ? null : (SCROLL_DEPTH_TAB_NAMES[type] ?? null);
     if (tabName === null) {
       return; // program detail / rebates / CESN's standalone help page aren't browsable tabs
@@ -372,15 +367,13 @@ const Results = ({ type }: ResultsProps) => {
   } else if (apiError) {
     return <ResultsError />;
   } else if (programId === undefined && type === 'help' && immediateHelpSuppressed) {
-    // Referrers that opted out of More Help must not reach it by URL either, now that no
-    // tab links there for them. This runs before the CESN branch below, so a suppressed
-    // referrer on CESN redirects here rather than landing on CESN's standalone help page.
+    // Suppressed referrers must not reach More Help by URL either. Must run before the
+    // CESN branch below, so a suppressed referrer on CESN redirects here too.
     return <Navigate to={addAdminToLink(`/${whiteLabel}/${uuid}/results/benefits`, isAdminView)} replace />;
   } else if (programId === undefined && type === 'help' && isEnergyCalculator) {
-    // CESN renders no tab bar (see Tabs.tsx), so Immediate Help stays the standalone page
-    // it is today, reached from the More Help button and keeping its drill-down "BACK TO
-    // RESULTS" affordance. Folding CESN into the tabbed layout instead would leave it with
-    // "BACK TO SCREENER" and no tab bar to return to results with.
+    // CESN has no tab bar (Tabs.tsx), so Immediate Help stays this standalone page,
+    // keeping its "BACK TO RESULTS" affordance. Folding it into the tabbed layout would
+    // leave "BACK TO SCREENER" with no tab bar to get back to results.
     return (
       <main className="benefits-form">
         <Grid container>
@@ -397,16 +390,12 @@ const Results = ({ type }: ResultsProps) => {
       </main>
     );
   } else if (programId === undefined && (type === 'program' || type === 'need' || type === 'help')) {
-    // Panel content and the tab that labels it, keyed by results type. Built here inside
-    // the render function — NOT at module scope — because Results.tsx sits in an import
-    // cycle (Results -> Tabs -> Results). A lookup built at module scope would read
-    // Programs/Needs/MoreHelp at module-evaluation time, which can be before those
-    // modules have finished initializing if the cycle is entered from one of them
-    // instead of from here, permanently baking in `undefined` with no ErrorBoundary to
-    // catch the resulting crash. Rendering never happens until the whole module graph
-    // has finished loading, so building it here is race-free. A Record rather than
-    // nested ternaries, so a fourth type is a compile error instead of a silent
-    // fallthrough to the Long-Term Benefits panel.
+    // Built inside render, not at module scope: Results.tsx has an import cycle
+    // (Results -> Tabs -> Results), and a module-scope lookup could read
+    // Programs/Needs/MoreHelp before they finish initializing, baking in `undefined`
+    // with no ErrorBoundary to catch it. Render only starts after the whole module
+    // graph loads, so this is safe. A Record (not nested ternaries) makes a missing
+    // type a compile error instead of a silent fallback to Long-Term Benefits.
     const panels: Record<ResultsTabId, { tabId: string; Content: ComponentType }> = {
       program: { tabId: 'long-term-benefits-tab', Content: Programs },
       need: { tabId: 'near-term-benefits-tab', Content: Needs },
@@ -422,8 +411,8 @@ const Results = ({ type }: ResultsProps) => {
             <div className="results-card-wrapper">
               <ResultsTabs activeTab={type} />
               <div id="results-tabpanel" role="tabpanel" aria-labelledby={panel.tabId} className="benefits-form results-card-body">
-                {/* Inside the panel, not above it: the summary is per-tab content, so it
-                    should be reachable when a screen reader moves into the active panel. */}
+                {/* Inside the panel, not above it — per-tab content should be reachable
+                    when a screen reader enters the active panel. */}
                 <ResultsSummary type={type} />
                 {type === 'program' && <ExternalApiFailureBanner />}
                 {type === 'program' && <UrgentNeedBanner />}

--- a/src/Components/Results/ResultsHeader/ResultsHeader.tsx
+++ b/src/Components/Results/ResultsHeader/ResultsHeader.tsx
@@ -14,8 +14,8 @@ import { useIsEnergyCalculator } from '../../EnergyCalculator/hooks';
 import EnergyCalculatorResultsHeader from '../../EnergyCalculator/Results/ResultsHeader';
 import ResultsSurvey from '../ResultsSurvey/ResultsSurvey';
 
-type ResultsHeaderProps = {
-  type: 'program' | 'need';
+type ResultsSummaryProps = {
+  type: 'program' | 'need' | 'help';
 };
 
 const ProgramsHeader = () => {
@@ -71,33 +71,47 @@ const ProgramsHeader = () => {
   );
 };
 
-const NeedsHeader = () => {
-  const { needs } = useResultsContext();
+// The per-tab summary block. Rendered BELOW the tab bar and inside the results card,
+// so it is separate from ResultsHeader (which stays above, full-bleed). The wrapper
+// div lives in here rather than in Results so the Immediate Help tab renders nothing
+// at all — `.results-header-container` has a fixed `height: 9rem`, which would leave
+// an empty gap if the wrapper rendered without a summary inside it.
+//
+// Shows only on Long-Term Benefits, per the PM. Additional Resources previously had its
+// own "N Resources Found" block (NeedsHeader), but that count already appears in the tab
+// label itself ("Additional Resources (N)"), so it was a pure duplicate carrying the
+// same visual weight as the real summary for no extra information — removed rather than
+// repositioned.
+export const ResultsSummary = ({ type }: ResultsSummaryProps) => {
+  const isEnergyCalculator = useIsEnergyCalculator();
+
+  if (isEnergyCalculator) {
+    return (
+      <div className="energy-calculator-results-header-container">
+        <EnergyCalculatorResultsHeader />
+      </div>
+    );
+  }
+
+  if (type !== 'program') {
+    return null;
+  }
 
   return (
-    <div className="results-needs-header-background">
-      <div className="results-needs-header">
-        <div className="results-needs-header-programs">{needs.length}</div>
-        <div className="results-needs-header-programs-text">
-          <FormattedMessage id="results.needHeader" defaultMessage="Resources Found" />
-        </div>
-      </div>
+    <div className="results-header-container">
+      <ProgramsHeader />
     </div>
   );
 };
 
-const ResultsHeader = ({ type }: ResultsHeaderProps) => {
+// Page-level chrome shared by every results tab: back/save buttons, the admin login,
+// and the NC feedback survey. Takes no `type` on purpose — it renders above the tab
+// bar and outside the results card, so it is identical whichever tab is active.
+const ResultsHeader = () => {
   const { whiteLabel, uuid } = useParams();
   const { staffToken, setStaffToken } = useContext(Context);
   const { isAdminView } = useResultsContext();
-  const isEnergyCalculator = useIsEnergyCalculator();
   const track = useTrackEvent();
-
-  let header = type === 'need' ? <NeedsHeader /> : <ProgramsHeader />;
-
-  if (isEnergyCalculator) {
-    header = <EnergyCalculatorResultsHeader />;
-  }
 
   return (
     <>
@@ -110,7 +124,6 @@ const ResultsHeader = ({ type }: ResultsHeaderProps) => {
       </div>
       {isAdminView && <Login setToken={setStaffToken} loggedIn={staffToken !== undefined} />}
       <ResultsSurvey />
-      <div className={isEnergyCalculator ? "energy-calculator-results-header-container" : "results-header-container"}>{header}</div>
     </>
   );
 };

--- a/src/Components/Results/ResultsHeader/ResultsHeader.tsx
+++ b/src/Components/Results/ResultsHeader/ResultsHeader.tsx
@@ -71,17 +71,10 @@ const ProgramsHeader = () => {
   );
 };
 
-// The per-tab summary block. Rendered BELOW the tab bar and inside the results card,
-// so it is separate from ResultsHeader (which stays above, full-bleed). The wrapper
-// div lives in here rather than in Results so the Immediate Help tab renders nothing
-// at all — `.results-header-container` has a fixed `height: 9rem`, which would leave
-// an empty gap if the wrapper rendered without a summary inside it.
-//
-// Shows only on Long-Term Benefits, per the PM. Additional Resources previously had its
-// own "N Resources Found" block (NeedsHeader), but that count already appears in the tab
-// label itself ("Additional Resources (N)"), so it was a pure duplicate carrying the
-// same visual weight as the real summary for no extra information — removed rather than
-// repositioned.
+// Rendered below the tab bar, inside the results card — separate from ResultsHeader,
+// which stays above. The wrapper div lives here (not in Results) so the Immediate Help
+// tab renders nothing: `.results-header-container` has a fixed height: 9rem, and an
+// empty wrapper would leave a gap.
 export const ResultsSummary = ({ type }: ResultsSummaryProps) => {
   const isEnergyCalculator = useIsEnergyCalculator();
 
@@ -104,9 +97,8 @@ export const ResultsSummary = ({ type }: ResultsSummaryProps) => {
   );
 };
 
-// Page-level chrome shared by every results tab: back/save buttons, the admin login,
-// and the NC feedback survey. Takes no `type` on purpose — it renders above the tab
-// bar and outside the results card, so it is identical whichever tab is active.
+// Elements shared by every tab: back/save buttons, admin login, NC survey. No `type`
+// prop — it renders above the tab bar, outside the results card, the same for every tab.
 const ResultsHeader = () => {
   const { whiteLabel, uuid } = useParams();
   const { staffToken, setStaffToken } = useContext(Context);

--- a/src/Components/Results/Tabs/Tabs.tsx
+++ b/src/Components/Results/Tabs/Tabs.tsx
@@ -96,10 +96,9 @@ const ResultsTabs = ({ activeTab }: ResultsTabsProps) => {
                   track('screener_results_tab_click', { tab_name: tab.trackName });
 
                   if (tab.id === 'help') {
-                    // Continuity for the GA4 "get help" metric: this event used to fire
-                    // only from the bottom More Help button, which this tab replaces. A
-                    // distinct `location` keeps the rollup comparable across the change
-                    // while still telling the two surfaces apart.
+                    // Continuity for GA4 "get help": this event used to fire only from
+                    // the bottom More Help button, which this tab replaces. Distinct
+                    // `location` keeps the rollup comparable while still separating the two surfaces.
                     track('screener_get_help_click', { location: 'immediate_help_tab' });
                   }
                 }}

--- a/src/Components/Results/Tabs/Tabs.tsx
+++ b/src/Components/Results/Tabs/Tabs.tsx
@@ -1,95 +1,117 @@
 import { useCallback, useMemo, useRef } from 'react';
-import { NavLink, useLocation, useNavigate } from 'react-router-dom';
-import { useResultsContext, useResultsLink } from '../Results';
+import { NavLink, useNavigate } from 'react-router-dom';
+import { useImmediateHelpSuppressed, useResultsContext, useResultsLink } from '../Results';
 import { Grid } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
 import { useTranslateNumber } from '../../../Assets/languageOptions';
 import { useIsEnergyCalculator } from '../../EnergyCalculator/hooks';
 import { useTrackEvent } from '../../../Assets/analytics';
+import { buildTabs, getNextTabIndex, ResultsTabId } from './buildTabs';
 
-const ResultsTabs = () => {
+type ResultsTabsProps = {
+  // Supplied by Results, which already knows which tab is rendering. Deriving it from
+  // the URL here instead would re-parse information the caller already has.
+  activeTab: ResultsTabId;
+};
+
+const ResultsTabs = ({ activeTab }: ResultsTabsProps) => {
   const { programs, needs } = useResultsContext();
   const translateNumber = useTranslateNumber();
-  const location = useLocation();
   const navigate = useNavigate();
 
   const benefitsLink = useResultsLink(`results/benefits`);
   const needsLink = useResultsLink(`results/near-term-needs`);
+  const helpLink = useResultsLink(`results/more-help`);
+  const immediateHelpSuppressed = useImmediateHelpSuppressed();
 
-  const isBenefitsActive = location.pathname.includes('benefits');
   const tabRefs = useRef<(HTMLAnchorElement | null)[]>([]);
-  const tabLinks = useMemo(() => [benefitsLink, needsLink], [benefitsLink, needsLink]);
   const track = useTrackEvent();
+
+  const tabs = useMemo(
+    () =>
+      buildTabs({
+        benefitsLink,
+        needsLink,
+        helpLink,
+        programCount: programs.length,
+        needCount: needs.length,
+        immediateHelpSuppressed,
+      }),
+    [benefitsLink, needsLink, helpLink, programs.length, needs.length, immediateHelpSuppressed],
+  );
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      const currentIndex = isBenefitsActive ? 0 : 1;
-      let nextIndex: number | null = null;
+      const currentIndex = tabs.findIndex((tab) => tab.id === activeTab);
 
-      if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
-        nextIndex = (currentIndex + 1) % 2;
-      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
-        nextIndex = (currentIndex - 1 + 2) % 2;
-      } else if (e.key === 'Home') {
-        nextIndex = 0;
-      } else if (e.key === 'End') {
-        nextIndex = 1;
+      if (currentIndex === -1) {
+        return;
       }
+
+      const nextIndex = getNextTabIndex(e.key, currentIndex, tabs.length);
 
       if (nextIndex !== null) {
         e.preventDefault();
         tabRefs.current[nextIndex]?.focus();
-        navigate(tabLinks[nextIndex]);
+        navigate(tabs[nextIndex].to);
       }
     },
-    [isBenefitsActive, navigate, tabLinks],
+    [activeTab, navigate, tabs],
   );
 
   const isEnergyCalculator = useIsEnergyCalculator();
   if (isEnergyCalculator) {
     return null;
   }
+
   return (
     <nav aria-label="Results">
-      <Grid container className="results-tab-container" role="tablist" onKeyDown={handleKeyDown}>
-        <Grid item xs={6} className="results-tab" role="presentation">
-          <NavLink
-            ref={(el) => { tabRefs.current[0] = el; }}
-            to={benefitsLink}
-            className={({ isActive }) => (isActive ? 'active' : '')}
-            id="long-term-benefits-tab"
-            data-testid="long-term-benefits-tab"
-            role="tab"
-            aria-selected={isBenefitsActive}
-            aria-controls="results-tabpanel"
-            tabIndex={isBenefitsActive ? 0 : -1}
-            onClick={() => track('screener_results_tab_click', { tab_name: 'long_term_benefits' })}
-          >
-            <span className="results-tab-label">
-              <FormattedMessage id="resultsOptions.longTermBenefits" defaultMessage="Long-Term Benefits " />(
-              {translateNumber(programs.length)})
-            </span>
-          </NavLink>
-        </Grid>
-        <Grid item xs={6} className="results-tab" role="presentation">
-          <NavLink
-            ref={(el) => { tabRefs.current[1] = el; }}
-            to={needsLink}
-            className={({ isActive }) => (isActive ? 'active' : '')}
-            id="near-term-benefits-tab"
-            data-testid="near-term-benefits-tab"
-            role="tab"
-            aria-selected={!isBenefitsActive}
-            aria-controls="results-tabpanel"
-            tabIndex={!isBenefitsActive ? 0 : -1}
-            onClick={() => track('screener_results_tab_click', { tab_name: 'additional_resources' })}
-          >
-            <span className="results-tab-label">
-              <FormattedMessage id="resultsOptions.nearTermBenefits" defaultMessage="Additional Resources " />(
-              {translateNumber(needs.length)})
-            </span>
-          </NavLink>
-        </Grid>
+      {/* data-tab-count scopes the three-tab CSS adjustments, so the two-tab layout
+          (referrers with `no_results_more_help`) renders exactly as it did before. */}
+      <Grid
+        container
+        className="results-tab-container"
+        data-tab-count={tabs.length}
+        role="tablist"
+        onKeyDown={handleKeyDown}
+      >
+        {tabs.map((tab, index) => {
+          const isActive = tab.id === activeTab;
+
+          return (
+            <Grid item xs={12 / tabs.length} key={tab.id} className="results-tab" role="presentation">
+              <NavLink
+                ref={(el) => {
+                  tabRefs.current[index] = el;
+                }}
+                to={tab.to}
+                className={isActive ? 'active' : ''}
+                id={tab.testId}
+                data-testid={tab.testId}
+                role="tab"
+                aria-selected={isActive}
+                aria-controls="results-tabpanel"
+                tabIndex={isActive ? 0 : -1}
+                onClick={() => {
+                  track('screener_results_tab_click', { tab_name: tab.trackName });
+
+                  if (tab.id === 'help') {
+                    // Continuity for the GA4 "get help" metric: this event used to fire
+                    // only from the bottom More Help button, which this tab replaces. A
+                    // distinct `location` keeps the rollup comparable across the change
+                    // while still telling the two surfaces apart.
+                    track('screener_get_help_click', { location: 'immediate_help_tab' });
+                  }
+                }}
+              >
+                <span className="results-tab-label">
+                  <FormattedMessage id={tab.labelId} defaultMessage={tab.defaultMessage} />
+                  {tab.count !== undefined && `(${translateNumber(tab.count)})`}
+                </span>
+              </NavLink>
+            </Grid>
+          );
+        })}
       </Grid>
     </nav>
   );

--- a/src/Components/Results/Tabs/buildTabs.test.ts
+++ b/src/Components/Results/Tabs/buildTabs.test.ts
@@ -29,8 +29,7 @@ describe('buildTabs', () => {
   });
 
   it('leaves Immediate Help without a count', () => {
-    // The resource list is fixed per-tenant config, so a count would be identical for
-    // every user of a white label and would imply a personalization that doesn't exist.
+    // Mirrors the no-count rationale in buildTabs.ts.
     expect(buildTabs(args).find((tab) => tab.id === 'help')?.count).toBeUndefined();
   });
 

--- a/src/Components/Results/Tabs/buildTabs.test.ts
+++ b/src/Components/Results/Tabs/buildTabs.test.ts
@@ -1,0 +1,108 @@
+import { buildTabs, getNextTabIndex } from './buildTabs';
+
+const args = {
+  benefitsLink: '/co/uuid/results/benefits',
+  needsLink: '/co/uuid/results/near-term-needs',
+  helpLink: '/co/uuid/results/more-help',
+  programCount: 4,
+  needCount: 2,
+  immediateHelpSuppressed: false,
+};
+
+describe('buildTabs', () => {
+  it('builds all three tabs in order by default', () => {
+    expect(buildTabs(args).map((tab) => tab.id)).toEqual(['program', 'need', 'help']);
+  });
+
+  it('omits the Immediate Help tab when the referrer suppresses it', () => {
+    const tabs = buildTabs({ ...args, immediateHelpSuppressed: true });
+
+    expect(tabs.map((tab) => tab.id)).toEqual(['program', 'need']);
+    expect(tabs.find((tab) => tab.id === 'help')).toBeUndefined();
+  });
+
+  it('puts the result counts on the two result tabs', () => {
+    const tabs = buildTabs(args);
+
+    expect(tabs.find((tab) => tab.id === 'program')?.count).toBe(4);
+    expect(tabs.find((tab) => tab.id === 'need')?.count).toBe(2);
+  });
+
+  it('leaves Immediate Help without a count', () => {
+    // The resource list is fixed per-tenant config, so a count would be identical for
+    // every user of a white label and would imply a personalization that doesn't exist.
+    expect(buildTabs(args).find((tab) => tab.id === 'help')?.count).toBeUndefined();
+  });
+
+  it('keeps the existing test ids so e2e selectors and aria wiring stay valid', () => {
+    expect(buildTabs(args).map((tab) => tab.testId)).toEqual([
+      'long-term-benefits-tab',
+      'near-term-benefits-tab',
+      'immediate-help-tab',
+    ]);
+  });
+
+  it('gives every tab a distinct GA4 tab_name', () => {
+    const trackNames = buildTabs(args).map((tab) => tab.trackName);
+
+    expect(trackNames).toEqual(['long_term_benefits', 'additional_resources', 'immediate_help']);
+    expect(new Set(trackNames).size).toBe(trackNames.length);
+  });
+
+  it('links each tab at its own route', () => {
+    const tabs = buildTabs(args);
+
+    expect(tabs.find((tab) => tab.id === 'program')?.to).toBe(args.benefitsLink);
+    expect(tabs.find((tab) => tab.id === 'need')?.to).toBe(args.needsLink);
+    expect(tabs.find((tab) => tab.id === 'help')?.to).toBe(args.helpLink);
+  });
+});
+
+describe('getNextTabIndex', () => {
+  it('moves forward and wraps at the end', () => {
+    expect(getNextTabIndex('ArrowRight', 0, 3)).toBe(1);
+    expect(getNextTabIndex('ArrowRight', 1, 3)).toBe(2);
+    expect(getNextTabIndex('ArrowRight', 2, 3)).toBe(0);
+    expect(getNextTabIndex('ArrowDown', 2, 3)).toBe(0);
+  });
+
+  it('moves backward and wraps at the start without going negative', () => {
+    expect(getNextTabIndex('ArrowLeft', 2, 3)).toBe(1);
+    expect(getNextTabIndex('ArrowLeft', 0, 3)).toBe(2);
+    expect(getNextTabIndex('ArrowUp', 0, 3)).toBe(2);
+  });
+
+  it('jumps to the first and last tab', () => {
+    expect(getNextTabIndex('Home', 2, 3)).toBe(0);
+    // Regression guard: End must be tabCount - 1. Generalising the old hardcoded
+    // `nextIndex = 1` to `tabs.length` would land out of bounds here.
+    expect(getNextTabIndex('End', 0, 3)).toBe(2);
+  });
+
+  it('still works with two tabs, for referrers that suppress Immediate Help', () => {
+    expect(getNextTabIndex('ArrowRight', 1, 2)).toBe(0);
+    expect(getNextTabIndex('ArrowLeft', 0, 2)).toBe(1);
+    expect(getNextTabIndex('End', 0, 2)).toBe(1);
+    expect(getNextTabIndex('Home', 1, 2)).toBe(0);
+  });
+
+  it('never returns an out-of-range index', () => {
+    for (const tabCount of [2, 3]) {
+      for (const key of ['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown', 'Home', 'End']) {
+        for (let current = 0; current < tabCount; current++) {
+          const next = getNextTabIndex(key, current, tabCount);
+
+          expect(next).not.toBeNull();
+          expect(next).toBeGreaterThanOrEqual(0);
+          expect(next).toBeLessThan(tabCount);
+        }
+      }
+    }
+  });
+
+  it('ignores keys that should not move focus', () => {
+    expect(getNextTabIndex('Enter', 0, 3)).toBeNull();
+    expect(getNextTabIndex('Tab', 0, 3)).toBeNull();
+    expect(getNextTabIndex('a', 0, 3)).toBeNull();
+  });
+});

--- a/src/Components/Results/Tabs/buildTabs.ts
+++ b/src/Components/Results/Tabs/buildTabs.ts
@@ -1,0 +1,92 @@
+export type ResultsTabId = 'program' | 'need' | 'help';
+
+export type TabDescriptor = {
+  id: ResultsTabId;
+  to: string;
+  testId: string;
+  labelId: string;
+  defaultMessage: string;
+  // undefined => no "(n)" suffix. Immediate Help opts out this way.
+  count?: number;
+  // GA4 `tab_name`; single source of truth so the literal isn't copy-pasted per tab.
+  trackName: string;
+};
+
+type BuildTabsArgs = {
+  benefitsLink: string;
+  needsLink: string;
+  helpLink: string;
+  programCount: number;
+  needCount: number;
+  immediateHelpSuppressed: boolean;
+};
+
+// Pure so the tab set can be tested without Router/Intl/Context providers.
+export function buildTabs({
+  benefitsLink,
+  needsLink,
+  helpLink,
+  programCount,
+  needCount,
+  immediateHelpSuppressed,
+}: BuildTabsArgs): TabDescriptor[] {
+  const tabs: TabDescriptor[] = [
+    {
+      id: 'program',
+      to: benefitsLink,
+      testId: 'long-term-benefits-tab',
+      labelId: 'resultsOptions.longTermBenefits',
+      defaultMessage: 'Long-Term Benefits ',
+      count: programCount,
+      trackName: 'long_term_benefits',
+    },
+    {
+      id: 'need',
+      to: needsLink,
+      testId: 'near-term-benefits-tab',
+      labelId: 'resultsOptions.nearTermBenefits',
+      defaultMessage: 'Additional Resources ',
+      count: needCount,
+      trackName: 'additional_resources',
+    },
+  ];
+
+  // No count on Immediate Help: the resource list comes from fixed per-tenant config
+  // rather than the household's results, so a count would be the same for every user
+  // of a white label and would imply a personalization that doesn't exist.
+  if (!immediateHelpSuppressed) {
+    tabs.push({
+      id: 'help',
+      to: helpLink,
+      testId: 'immediate-help-tab',
+      labelId: 'resultsOptions.immediateHelp',
+      defaultMessage: 'Immediate Help',
+      trackName: 'immediate_help',
+    });
+  }
+
+  return tabs;
+}
+
+// Roving-tabindex arithmetic for the tab bar, extracted so it can be tested without
+// rendering. Returns null for keys that shouldn't move focus. `tabCount` varies (2 when
+// a referrer suppresses Immediate Help, 3 otherwise), so nothing here may assume 3.
+export function getNextTabIndex(key: string, currentIndex: number, tabCount: number): number | null {
+  if (key === 'ArrowRight' || key === 'ArrowDown') {
+    return (currentIndex + 1) % tabCount;
+  }
+
+  if (key === 'ArrowLeft' || key === 'ArrowUp') {
+    return (currentIndex - 1 + tabCount) % tabCount;
+  }
+
+  if (key === 'Home') {
+    return 0;
+  }
+
+  if (key === 'End') {
+    return tabCount - 1;
+  }
+
+  return null;
+}

--- a/src/Components/Results/Tabs/buildTabs.ts
+++ b/src/Components/Results/Tabs/buildTabs.ts
@@ -51,9 +51,8 @@ export function buildTabs({
     },
   ];
 
-  // No count on Immediate Help: the resource list comes from fixed per-tenant config
-  // rather than the household's results, so a count would be the same for every user
-  // of a white label and would imply a personalization that doesn't exist.
+  // No count: the resource list is fixed per-tenant config, not household-specific,
+  // so a count would falsely imply personalization.
   if (!immediateHelpSuppressed) {
     tabs.push({
       id: 'help',
@@ -68,9 +67,9 @@ export function buildTabs({
   return tabs;
 }
 
-// Roving-tabindex arithmetic for the tab bar, extracted so it can be tested without
-// rendering. Returns null for keys that shouldn't move focus. `tabCount` varies (2 when
-// a referrer suppresses Immediate Help, 3 otherwise), so nothing here may assume 3.
+// Roving-tabindex arithmetic, extracted so it's testable without rendering.
+// Returns null for keys that shouldn't move focus. `tabCount` varies (2 or 3),
+// so nothing here may assume 3.
 export function getNextTabIndex(key: string, currentIndex: number, tabCount: number): number | null {
   if (key === 'ArrowRight' || key === 'ArrowDown') {
     return (currentIndex + 1) % tabCount;

--- a/tests/helpers/results.ts
+++ b/tests/helpers/results.ts
@@ -171,13 +171,15 @@ export async function clickBackToResults(page: Page): Promise<void> {
 }
 
 /**
- * Clicks on a results page tab (Near-Term or Long-Term) using its data-testid.
+ * Clicks on a results page tab (Long-Term, Near-Term, or Immediate Help) using its
+ * data-testid. Note that `immediate-help-tab` is not rendered for referrers carrying the
+ * `no_results_more_help` uiOption, nor on the CESN white label, which has no tab bar.
  * @param page - Playwright page instance
  * @param tabTestId - The data-testid of the tab to click.
  */
 export async function clickResultsTab(
   page: Page,
-  tabTestId: 'near-term-benefits-tab' | 'long-term-benefits-tab',
+  tabTestId: 'near-term-benefits-tab' | 'long-term-benefits-tab' | 'immediate-help-tab',
 ): Promise<void> {
   try {
     const tabSelector = `[data-testid="${tabTestId}"]`;


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes #[MFB-824](https://linear.app/myfriendben/issue/MFB-824/update-tab-design-on-results-page)
- Related PR: [Backend PR](https://github.com/MyFriendBen/benefits-api/pull/1703)

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- ...

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run:
- Configuration updates needed:
- Environment variables/settings to add:
- Manual testing steps:

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script:
- Update production config:
- Admin updates needed:
- Notify team/users of:

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
- Future considerations:
