### PR TITLE
MFB-1567: Remove the validations admin UI and frozen-screen banner

### DIFF
--- a/src/Assets/updateFormData.tsx
+++ b/src/Assets/updateFormData.tsx
@@ -11,7 +11,6 @@ export function useUpdateFormData() {
       ...formData,
       isTest: response.is_test ?? false,
       isTestData: response.is_test_data ?? false,
-      frozen: response.frozen,
       externalID: response.external_id ?? undefined,
       agreeToTermsOfService: response.agree_to_tos ?? false,
       is13OrOlder: response.is_13_or_older ?? false,

--- a/src/Components/Header/Header.css
+++ b/src/Components/Header/Header.css
@@ -54,10 +54,6 @@
   z-index: 1;
 }
 
-.MuiPaper-root.header-full-width-container.frozen {
-  height: 6.5rem;
-}
-
 #nav-container {
   display: flex;
   flex-direction: row;
@@ -151,13 +147,6 @@
 .white-header #select-language:focus-visible,
 .white-header #select-language .MuiSelect-select:focus-visible {
   outline: 2px solid var(--primary-color);
-}
-
-.header-frozen-message-container {
-  background-color: var(--hover-color);
-  text-align: center;
-  height: max-content;
-  font-weight: bold;
 }
 
 .eaglecounty-logo-size {

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -14,7 +14,7 @@ import { useTrackEvent } from '../../Assets/analytics';
 
 const Header = () => {
   const context = useContext(Context);
-  const { formData, getReferrer, whiteLabel } = context;
+  const { getReferrer, whiteLabel } = context;
   const languageOptions = useConfig<{ [key: string]: string }>('language_options');
   const queryString = useQueryString();
   const landingPageQueryString = useQueryString({ path: null });
@@ -68,10 +68,6 @@ const Header = () => {
   const containerClass = useMemo(() => {
     let className = 'header-full-width-container';
 
-    if (formData.frozen) {
-      className += ' frozen';
-    }
-
     if (getReferrer('uiOptions').includes('white_header')) {
       className += ' white-header';
     }
@@ -81,7 +77,7 @@ const Header = () => {
     }
 
     return className;
-  }, [formData.frozen]);
+  }, []);
 
   return (
     <nav>
@@ -120,14 +116,6 @@ const Header = () => {
             </Select>
           </div>
         </AppBar>
-        {formData.frozen && (
-          <div className="header-frozen-message-container">
-            <FormattedMessage
-              id="header.frozen.message"
-              defaultMessage="This screen is frozen. Changes you make will not be saved."
-            />
-          </div>
-        )}
       </Paper>
     </nav>
   );

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -65,19 +65,21 @@ const Header = () => {
     return dropdownMenuItems;
   };
 
+  const uiOptions = getReferrer('uiOptions');
+
   const containerClass = useMemo(() => {
     let className = 'header-full-width-container';
 
-    if (getReferrer('uiOptions').includes('white_header')) {
+    if (uiOptions.includes('white_header')) {
       className += ' white-header';
     }
 
-    if (getReferrer('uiOptions').includes('small_header_language_dropdown')) {
+    if (uiOptions.includes('small_header_language_dropdown')) {
       className += ' small-header-language-dropdown';
     }
 
     return className;
-  }, []);
+  }, [uiOptions]);
 
   return (
     <nav>

--- a/src/Components/Results/FormattedValue.tsx
+++ b/src/Components/Results/FormattedValue.tsx
@@ -2,7 +2,6 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { useTranslateNumber } from '../../Assets/languageOptions';
 import { FormattedMessageType } from '../../Types/Questions';
 import { Program, ProgramCategory } from '../../Types/Results';
-import { findValidationForProgram, useResultsContext } from './Results';
 
 export function programValue(program: Program) {
   let total = program.household_value;
@@ -95,8 +94,7 @@ export const formatToUSD = (num: number) => {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(num);
 };
 
-function useOverrideValue(program: Program, value: string, expectedValue?: string) {
-  const { isAdminView } = useResultsContext();
+function useOverrideValue(program: Program, value: string) {
   const intl = useIntl();
 
   if (program.estimated_value_override.default_message !== '') {
@@ -104,10 +102,6 @@ function useOverrideValue(program: Program, value: string, expectedValue?: strin
       id: program.estimated_value_override.label,
       defaultMessage: program.estimated_value_override.default_message,
     });
-  }
-
-  if (isAdminView && expectedValue !== undefined) {
-    return `${expectedValue} => ${value}`;
   }
 
   return value;
@@ -128,9 +122,7 @@ function useValueFormats(): DefaultMap<(program: Program) => string> {
       return translateNumber(formatToUSD(programValue(program) / 12)) + perMonth;
     },
     lump_sum: (program: Program) => {
-      return (
-        translateNumber(formatToUSD(programValue(program)))
-      );
+      return translateNumber(formatToUSD(programValue(program)));
     },
     estimated_annual: (program: Program) => {
       const perYear = intl.formatMessage({ id: 'results.programs.values.formats.per_year', defaultMessage: '/year' });
@@ -143,15 +135,7 @@ export function useFormatDisplayValue(program: Program) {
   const formats = useValueFormats();
   const calculator = formats[program.value_format ?? 'default'] ?? formats.default;
   const value = calculator(program);
-  const { validations } = useResultsContext();
-  const validation = findValidationForProgram(validations, program);
-  const translateNumber = useTranslateNumber();
-
-  // Call the hook unconditionally (rules-of-hooks): expectedValue is simply
-  // undefined when there's no validation, which useOverrideValue handles.
-  const expectedValue =
-    validation !== undefined ? translateNumber(formatToUSD(Number(validation.value) / 12)) : undefined;
-  return useOverrideValue(program, value, expectedValue);
+  return useOverrideValue(program, value);
 }
 
 export function YearlyValueLabel({ program }: { program: Program }) {
@@ -176,13 +160,7 @@ export function YearlyValueLabel({ program }: { program: Program }) {
 
 export function useFormatYearlyValue(program: Program) {
   const translateNumber = useTranslateNumber();
-  const { validations } = useResultsContext();
-  const validation = findValidationForProgram(validations, program);
 
   const value = translateNumber(formatToUSD(programValue(program)));
-
-  // Call the hook unconditionally (rules-of-hooks): expectedValue is simply
-  // undefined when there's no validation, which useOverrideValue handles.
-  const expectedValue = validation !== undefined ? translateNumber(formatToUSD(Number(validation.value))) : undefined;
-  return useOverrideValue(program, value, expectedValue);
+  return useOverrideValue(program, value);
 }

--- a/src/Components/Results/ProgramPage/ProgramPage.tsx
+++ b/src/Components/Results/ProgramPage/ProgramPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Program } from '../../../Types/Results';
 import ResultsTranslate from '../Translate/Translate';
 import BackAndSaveButtons from '../BackAndSaveButtons/BackAndSaveButtons';
@@ -8,13 +8,11 @@ import './ProgramPage.css';
 import WarningMessage from '../../WarningComponent/WarningMessage';
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Context } from '../../Wrapper/Wrapper';
-import { findProgramById, findValidationForProgram, useResultsContext, useResultsLink } from '../Results';
-import { deleteValidation, postValidation } from '../../../apiCalls';
+import { findProgramById, useResultsContext, useResultsLink } from '../Results';
 import { Language } from '../../../Assets/languageOptions';
 import { allNavigatorLanguages } from './NavigatorLanguages';
 import { formatPhoneNumber, ICON_NAME_MAP } from '../helpers';
 import { Icon } from '../../Icon/Icon';
-import useScreenApi from '../../../Assets/updateScreen';
 import { Box, Button, ButtonGroup, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from '@mui/material';
 import JsonView from '@uiw/react-json-view';
 import { redactPolicyEngineData } from '../../../Assets/policyEngineRedaction';
@@ -29,11 +27,9 @@ type IconRendererProps = {
 };
 
 const ProgramPage = ({ program }: ProgramPageProps) => {
-  const { uuid } = useParams();
-  const { formData, staffToken } = useContext(Context);
-  const { isAdminView, validations, setValidations, programCategories, filterState } = useResultsContext();
+  const { staffToken } = useContext(Context);
+  const { isAdminView, programCategories, filterState } = useResultsContext();
   const intl = useIntl();
-  const { fetchScreen } = useScreenApi();
   const track = useTrackEvent();
   const trackItemList = useTrackItemList();
   const [openPEmodal, setOpenPEModal] = useState(false);
@@ -98,62 +94,6 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
     const lucideIconName = ICON_NAME_MAP[headingType] ?? ICON_NAME_MAP['default'];
     return <Icon name={lucideIconName} />;
   };
-  const currentValidation = findValidationForProgram(validations, program);
-
-  const saveValidation = async () => {
-    if (uuid === undefined) {
-      throw new Error('somehow the uuid does not exist');
-    }
-
-    if (staffToken === undefined) {
-      throw new Error('you must be logged in to create a validation');
-    }
-
-    const body = {
-      screen_uuid: uuid,
-      program_name: program.external_name,
-      eligible: program.eligible,
-      value: program.estimated_value,
-    };
-
-    try {
-      const response = await postValidation(body, staffToken);
-      setValidations([...validations, response]);
-      fetchScreen();
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  const removeValidation = async () => {
-    if (currentValidation === undefined) {
-      throw new Error('there are no validations for this program');
-    }
-    if (staffToken === undefined) {
-      throw new Error('you must be logged in to create a validation');
-    }
-
-    try {
-      await deleteValidation(currentValidation.id, staffToken);
-      const newValidations = validations.filter((validation) => validation.id !== currentValidation?.id);
-      setValidations(newValidations);
-      if (newValidations.length === 0) {
-        fetchScreen();
-      }
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  const toggleValidation = async () => {
-    if (currentValidation !== undefined) {
-      removeValidation();
-      return;
-    }
-
-    saveValidation();
-  };
-
   const category = programCategories.find((category) => {
     for (const categoryProgram of category.programs) {
       if (categoryProgram.external_name === program.external_name) {
@@ -269,258 +209,253 @@ const ProgramPage = ({ program }: ProgramPageProps) => {
         />
       </div>
       <main className="benefits-form program-page-container">
-      <div className="icon-header-est-values">
-        {displayIconAndHeader(program)}
-        {displayEstimatedValueAndTime(program)}
-      </div>
-      {warningMessages.length > 0 && (
-        <div className="results-program-page-warning-container">
-          {warningMessages.map((warning, key) => {
-            return <WarningMessage warning={warning} key={key} />;
-          })}
+        <div className="icon-header-est-values">
+          {displayIconAndHeader(program)}
+          {displayEstimatedValueAndTime(program)}
         </div>
-      )}
-      <div className="apply-button-container">
-        {program.apply_button_link.default_message !== '' && (
-          <a
-            className="apply-online-button"
-            href={programApplyButtonLink}
-            target="_blank"
-            onClick={() =>
-              track('screener_apply_click', {
-                program_id: String(program.program_id),
-                url: programApplyButtonLink,
-              })
-            }
-          >
-            {program.apply_button_description.default_message == '' ? (
-              <FormattedMessage id="results.apply-online" defaultMessage="Apply Online" />
-            ) : (
-              <ResultsTranslate translation={program.apply_button_description} />
-            )}
-          </a>
+        {warningMessages.length > 0 && (
+          <div className="results-program-page-warning-container">
+            {warningMessages.map((warning, key) => {
+              return <WarningMessage warning={warning} key={key} />;
+            })}
+          </div>
         )}
-        <>
-          {isAdminView && !!staffToken && (
+        <div className="apply-button-container">
+          {program.apply_button_link.default_message !== '' && (
             <a
-              role="button"
-              className="pe-request-button"
-              onClick={openPolicyEngineRequest}
-              data-testid="pe-data-button"
+              className="apply-online-button"
+              href={programApplyButtonLink}
+              target="_blank"
+              onClick={() =>
+                track('screener_apply_click', {
+                  program_id: String(program.program_id),
+                  url: programApplyButtonLink,
+                })
+              }
             >
-              <FormattedMessage id="policy_engine_request_button" defaultMessage="Policy Engine API" />
+              {program.apply_button_description.default_message == '' ? (
+                <FormattedMessage id="results.apply-online" defaultMessage="Apply Online" />
+              ) : (
+                <ResultsTranslate translation={program.apply_button_description} />
+              )}
             </a>
           )}
+          <>
+            {isAdminView && !!staffToken && (
+              <a
+                role="button"
+                className="pe-request-button"
+                onClick={openPolicyEngineRequest}
+                data-testid="pe-data-button"
+              >
+                <FormattedMessage id="policy_engine_request_button" defaultMessage="Policy Engine API" />
+              </a>
+            )}
 
-          <Dialog
-            open={openPEmodal}
-            onClose={closePolicyEngineRequest}
-            maxWidth="md"
-            fullWidth
-            disableScrollLock
-            data-testid="pe-data-dialog"
-            PaperProps={{
-              sx: {
-                height: '75vh',
-                display: 'flex',
-                flexDirection: 'column',
-              },
-            }}
-          >
-            <DialogTitle>
-              <FormattedMessage id="policy_engine_modal_title" defaultMessage="Policy Engine API Data" />
-            </DialogTitle>
-            <DialogContent
-              dividers
-              sx={{
-                flex: 1,
-                overflowY: 'auto',
-                p: 2,
+            <Dialog
+              open={openPEmodal}
+              onClose={closePolicyEngineRequest}
+              maxWidth="md"
+              fullWidth
+              disableScrollLock
+              data-testid="pe-data-dialog"
+              PaperProps={{
+                sx: {
+                  height: '75vh',
+                  display: 'flex',
+                  flexDirection: 'column',
+                },
               }}
             >
-              <Box
+              <DialogTitle>
+                <FormattedMessage id="policy_engine_modal_title" defaultMessage="Policy Engine API Data" />
+              </DialogTitle>
+              <DialogContent
+                dividers
                 sx={{
-                  display: 'flex',
-                  justifyContent: 'flex-end',
-                  marginBottom: 2,
+                  flex: 1,
+                  overflowY: 'auto',
+                  p: 2,
                 }}
               >
-                <ButtonGroup variant="text" color="primary" size="small">
-                  <Button id='policy_engine_expand_all_button' onClick={() => setCollapsed(false)}>Expand All</Button>
-                  <Button id='policy_engine_collapse_button' onClick={() => setCollapsed(3)}>By Default</Button>
-                </ButtonGroup>
-              </Box>
-              <Typography component="pre" style={{ whiteSpace: 'pre-wrap' }}>
-                <JsonView value={redacted} collapsed={collapsed} />
-              </Typography>
-            </DialogContent>
-            <DialogActions>
-              <div className="pe-modal-button-container">
-                <a
-                  role="button"
-                  className="pe-request-button"
-                  onClick={downloadPolicyEngineRequest}
-                  data-testid="pe-data-download-button"
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'flex-end',
+                    marginBottom: 2,
+                  }}
                 >
-                  <FormattedMessage id="policy_engine_download_button" defaultMessage="Download" />
-                </a>
-                <a
-                  role="button"
-                  className="pe-request-button"
-                  onClick={closePolicyEngineRequest}
-                  data-testid="pe-data-close-button"
-                >
-                  <FormattedMessage id="policy_engine_close_button" defaultMessage="Close" />
-                </a>
-              </div>
-            </DialogActions>
-          </Dialog>
-        </>
-        {isAdminView && staffToken !== undefined && formData.isTestData && (
-          <a role="button" className="apply-online-button" onClick={toggleValidation}>
-            {currentValidation === undefined ? (
-              <FormattedMessage id="results.validations.button.add" defaultMessage="Create Validation" />
-            ) : (
-              <FormattedMessage id="results.validations.button.remove" defaultMessage="Remove Validation" />
-            )}
-          </a>
-        )}
-      </div>
-      <div className="content-width">
-        {program.navigators.length > 0 && (
-          <section className="apply-box">
-            <h2 className="content-header">
-              <FormattedMessage id="results.get-help-applying" defaultMessage="Get Help Applying" />
-            </h2>
-            <ul className="apply-box-list">
-              {program.navigators.map((navigator, index) => (
-                <li key={index} className="apply-info">
-                  {navigator.name && (
-                    <p className="navigator-name">
-                      <ResultsTranslate translation={navigator.name} />
-                    </p>
-                  )}
-                  {navigator.languages && displayLanguageFlags(navigator.languages)}
-                  <div className="address-info">
-                    {navigator.description && (
-                      <p className="navigator-desc">
-                        <ResultsTranslate translation={navigator.description} />
+                  <ButtonGroup variant="text" color="primary" size="small">
+                    <Button id="policy_engine_expand_all_button" onClick={() => setCollapsed(false)}>
+                      Expand All
+                    </Button>
+                    <Button id="policy_engine_collapse_button" onClick={() => setCollapsed(3)}>
+                      By Default
+                    </Button>
+                  </ButtonGroup>
+                </Box>
+                <Typography component="pre" style={{ whiteSpace: 'pre-wrap' }}>
+                  <JsonView value={redacted} collapsed={collapsed} />
+                </Typography>
+              </DialogContent>
+              <DialogActions>
+                <div className="pe-modal-button-container">
+                  <a
+                    role="button"
+                    className="pe-request-button"
+                    onClick={downloadPolicyEngineRequest}
+                    data-testid="pe-data-download-button"
+                  >
+                    <FormattedMessage id="policy_engine_download_button" defaultMessage="Download" />
+                  </a>
+                  <a
+                    role="button"
+                    className="pe-request-button"
+                    onClick={closePolicyEngineRequest}
+                    data-testid="pe-data-close-button"
+                  >
+                    <FormattedMessage id="policy_engine_close_button" defaultMessage="Close" />
+                  </a>
+                </div>
+              </DialogActions>
+            </Dialog>
+          </>
+        </div>
+        <div className="content-width">
+          {program.navigators.length > 0 && (
+            <section className="apply-box">
+              <h2 className="content-header">
+                <FormattedMessage id="results.get-help-applying" defaultMessage="Get Help Applying" />
+              </h2>
+              <ul className="apply-box-list">
+                {program.navigators.map((navigator, index) => (
+                  <li key={index} className="apply-info">
+                    {navigator.name && (
+                      <p className="navigator-name">
+                        <ResultsTranslate translation={navigator.name} />
                       </p>
                     )}
-                    {navigator.assistance_link.default_message && (
-                      <div>
+                    {navigator.languages && displayLanguageFlags(navigator.languages)}
+                    <div className="address-info">
+                      {navigator.description && (
+                        <p className="navigator-desc">
+                          <ResultsTranslate translation={navigator.description} />
+                        </p>
+                      )}
+                      {navigator.assistance_link.default_message && (
+                        <div>
+                          <a
+                            href={navigator.assistance_link.default_message}
+                            target="_blank"
+                            className="link-color"
+                            onClick={() =>
+                              track('screener_navigator_engaged', {
+                                program_id: String(program.program_id),
+                                navigator_id: navigator.id,
+                                navigator_name: navigator.name.default_message,
+                                contact_method: 'website',
+                                url: navigator.assistance_link.default_message,
+                              })
+                            }
+                          >
+                            <FormattedMessage id="results.visit-webiste" defaultMessage="Visit Website" />
+                          </a>
+                        </div>
+                      )}
+                      {navigator.email.default_message && (
+                        <div>
+                          <a
+                            href={`mailto:${navigator.email.default_message}`}
+                            className="link-color email-link"
+                            onClick={() =>
+                              track('screener_navigator_engaged', {
+                                program_id: String(program.program_id),
+                                navigator_id: navigator.id,
+                                navigator_name: navigator.name.default_message,
+                                contact_method: 'email',
+                              })
+                            }
+                          >
+                            <ResultsTranslate translation={navigator.email} />
+                          </a>
+                        </div>
+                      )}
+                      {navigator.phone_number && (
+                        <div>
+                          <a
+                            href={`tel:${navigator.phone_number}`}
+                            className="link-color phone-link"
+                            onClick={() =>
+                              track('screener_navigator_engaged', {
+                                program_id: String(program.program_id),
+                                navigator_id: navigator.id,
+                                navigator_name: navigator.name.default_message,
+                                contact_method: 'phone',
+                              })
+                            }
+                          >
+                            {formatPhoneNumber(navigator.phone_number)}
+                          </a>
+                        </div>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+          {program.documents.length > 0 && (
+            <section className="required-docs">
+              <h3 className="content-header">
+                <FormattedMessage
+                  id="results.required-documents-checklist"
+                  defaultMessage="Required Key Documents Checklist"
+                />
+              </h3>
+              <ul className="required-docs-list">
+                {program.documents.map((document, index) => (
+                  <li key={index}>
+                    {<ResultsTranslate translation={document.text} />}
+                    {document.link_url.default_message && document.link_text.default_message && (
+                      <span className="required-docs-link">
                         <a
-                          href={navigator.assistance_link.default_message}
+                          href={document.link_url.default_message}
                           target="_blank"
                           className="link-color"
                           onClick={() =>
-                            track('screener_navigator_engaged', {
+                            track('screener_program_document_download', {
                               program_id: String(program.program_id),
-                              navigator_id: navigator.id,
-                              navigator_name: navigator.name.default_message,
-                              contact_method: 'website',
-                              url: navigator.assistance_link.default_message,
+                              document_name: document.text.default_message || undefined,
                             })
                           }
                         >
-                          <FormattedMessage id="results.visit-webiste" defaultMessage="Visit Website" />
+                          <ResultsTranslate translation={document.link_text} />
                         </a>
-                      </div>
+                      </span>
                     )}
-                    {navigator.email.default_message && (
-                      <div>
-                        <a
-                          href={`mailto:${navigator.email.default_message}`}
-                          className="link-color email-link"
-                          onClick={() =>
-                            track('screener_navigator_engaged', {
-                              program_id: String(program.program_id),
-                              navigator_id: navigator.id,
-                              navigator_name: navigator.name.default_message,
-                              contact_method: 'email',
-                            })
-                          }
-                        >
-                          <ResultsTranslate translation={navigator.email} />
-                        </a>
-                      </div>
-                    )}
-                    {navigator.phone_number && (
-                      <div>
-                        <a
-                          href={`tel:${navigator.phone_number}`}
-                          className="link-color phone-link"
-                          onClick={() =>
-                            track('screener_navigator_engaged', {
-                              program_id: String(program.program_id),
-                              navigator_id: navigator.id,
-                              navigator_name: navigator.name.default_message,
-                              contact_method: 'phone',
-                            })
-                          }
-                        >
-                          {formatPhoneNumber(navigator.phone_number)}
-                        </a>
-                      </div>
-                    )}
-                  </div>
-                </li>
-              ))}
-            </ul>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+          <section className="program-description">
+            <ResultsTranslate translation={program.description} />
           </section>
-        )}
-        {program.documents.length > 0 && (
-          <section className="required-docs">
-            <h3 className="content-header">
-              <FormattedMessage
-                id="results.required-documents-checklist"
-                defaultMessage="Required Key Documents Checklist"
-              />
-            </h3>
-            <ul className="required-docs-list">
-              {program.documents.map((document, index) => (
-                <li key={index}>
-                  {<ResultsTranslate translation={document.text} />}
-                  {document.link_url.default_message && document.link_text.default_message && (
-                    <span className="required-docs-link">
-                      <a
-                        href={document.link_url.default_message}
-                        target="_blank"
-                        className="link-color"
-                        onClick={() =>
-                          track('screener_program_document_download', {
-                            program_id: String(program.program_id),
-                            document_name: document.text.default_message || undefined,
-                          })
-                        }
-                      >
-                        <ResultsTranslate translation={document.link_text} />
-                      </a>
-                    </span>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
-        <section className="program-description">
-          <ResultsTranslate translation={program.description} />
-        </section>
-        {program.required_programs.length > 0 && (
-          <section className="program-page-required-programs-section">
-            <h3 className="program-page-required-programs-header">
-              <FormattedMessage
-                id="programPage.requiredPrograms.header"
-                defaultMessage="Enrollment in one of the following programs is required to be eligible for this program:"
-              />
-            </h3>
-            {program.required_programs.map((programId) => {
-              return <RequiredProgram programId={programId} key={programId} />;
-            })}
-          </section>
-        )}
-      </div>
-    </main>
+          {program.required_programs.length > 0 && (
+            <section className="program-page-required-programs-section">
+              <h3 className="program-page-required-programs-header">
+                <FormattedMessage
+                  id="programPage.requiredPrograms.header"
+                  defaultMessage="Enrollment in one of the following programs is required to be eligible for this program:"
+                />
+              </h3>
+              {program.required_programs.map((programId) => {
+                return <RequiredProgram programId={programId} key={programId} />;
+              })}
+            </section>
+          )}
+        </div>
+      </main>
     </>
   );
 };

--- a/src/Components/Results/Programs/ProgramCard.css
+++ b/src/Components/Results/Programs/ProgramCard.css
@@ -11,14 +11,6 @@
   margin-bottom: 1rem;
 }
 
-.result-program-container.passed {
-  background-color: #d9ead3;
-}
-
-.result-program-container.failed {
-  background-color: #ea9999;
-}
-
 .result-program-container hr {
   background-color: var(--secondary-color);
   width: 98%;

--- a/src/Components/Results/Programs/ProgramCard.test.tsx
+++ b/src/Components/Results/Programs/ProgramCard.test.tsx
@@ -10,10 +10,9 @@ import { createProgram, createMemberEligibility, createFormData } from '../testH
 
 // Mock Results module hooks
 jest.mock('../Results', () => ({
-  useResultsContext: () => ({ validations: [], isAdminView: false }),
+  useResultsContext: () => ({ isAdminView: false }),
   useResultsLink: (link: string) => `/test/uuid/${link}`,
   findMemberEligibilityMember: jest.requireActual('../Results').findMemberEligibilityMember,
-  findValidationForProgram: jest.requireActual('../Results').findValidationForProgram,
 }));
 
 // Mock FormattedValue
@@ -42,7 +41,13 @@ const createMember = (overrides: Partial<HouseholdData> = {}): HouseholdData => 
   birthYear: 1990,
   birthMonth: 1,
   relationshipToHH: 'headOfHousehold',
-  conditions: { student: false, pregnant: false, blindOrVisuallyImpaired: false, disabled: false, longTermDisability: false },
+  conditions: {
+    student: false,
+    pregnant: false,
+    blindOrVisuallyImpaired: false,
+    disabled: false,
+    longTermDisability: false,
+  },
   hasIncome: false,
   incomeStreams: [],
   ...overrides,
@@ -80,7 +85,7 @@ const createContextValue = (config: Config | undefined, formData = createFormDat
     hasBenefitsPrograms: [],
     hasBenefitsProgramsLoading: false,
     hasBenefitsProgramsError: false,
-  }) as WrapperContext;
+  } as WrapperContext);
 
 const renderProgramCard = (
   program: ReturnType<typeof createProgram>,
@@ -118,10 +123,7 @@ describe('ProgramCard - Eligibility Tags', () => {
     });
 
     const programWithMembers = createProgram({
-      members: [
-        createMemberEligibility('hoh', true, 100),
-        createMemberEligibility('child-1', true, 50),
-      ],
+      members: [createMemberEligibility('hoh', true, 100), createMemberEligibility('child-1', true, 50)],
     });
 
     it('should not show eligibility tags when feature flag is off', () => {
@@ -144,9 +146,7 @@ describe('ProgramCard - Eligibility Tags', () => {
     it('should not show eligibility tags for single-member household even with flag on', () => {
       const singleMemberFormData = createFormData({
         householdSize: 1,
-        householdData: [
-          createMember({ id: 1, frontendId: 'hoh', relationshipToHH: 'headOfHousehold' }),
-        ],
+        householdData: [createMember({ id: 1, frontendId: 'hoh', relationshipToHH: 'headOfHousehold' })],
       });
 
       const program = createProgram({
@@ -204,10 +204,7 @@ describe('ProgramCard - Eligibility Tags', () => {
 
     it('should show tags for all eligible members when all are eligible', () => {
       const program = createProgram({
-        members: [
-          createMemberEligibility('hoh', true, 100),
-          createMemberEligibility('child-1', true, 50),
-        ],
+        members: [createMemberEligibility('hoh', true, 100), createMemberEligibility('child-1', true, 50)],
       });
 
       renderProgramCard(program, configWithFlag(true), twoMemberFormData);
@@ -219,10 +216,7 @@ describe('ProgramCard - Eligibility Tags', () => {
     it('should not show tags when no members are eligible and program is not eligible', () => {
       const program = createProgram({
         eligible: false,
-        members: [
-          createMemberEligibility('hoh', false, 0),
-          createMemberEligibility('child-1', false, 0),
-        ],
+        members: [createMemberEligibility('hoh', false, 0), createMemberEligibility('child-1', false, 0)],
       });
 
       renderProgramCard(program, configWithFlag(true), twoMemberFormData);
@@ -290,14 +284,18 @@ describe('ProgramCard - Eligibility Tags', () => {
         householdSize: 2,
         householdData: [
           createMember({ id: 1, frontendId: 'hoh', relationshipToHH: 'headOfHousehold' }),
-          createMember({ id: 2, frontendId: 'foster-1', relationshipToHH: 'fosterChild', birthYear: 2018, birthMonth: 3 }),
+          createMember({
+            id: 2,
+            frontendId: 'foster-1',
+            relationshipToHH: 'fosterChild',
+            birthYear: 2018,
+            birthMonth: 3,
+          }),
         ],
       });
 
       const program = createProgram({
-        members: [
-          createMemberEligibility('foster-1', true, 50),
-        ],
+        members: [createMemberEligibility('foster-1', true, 50)],
       });
 
       renderProgramCard(program, configWithStringRelation, twoMemberFormData);
@@ -324,9 +322,7 @@ describe('ProgramCard - Eligibility Tags', () => {
       });
 
       const program = createProgram({
-        members: [
-          createMemberEligibility('sib-1', true, 50),
-        ],
+        members: [createMemberEligibility('sib-1', true, 50)],
       });
 
       renderProgramCard(program, configWithMissingRelation, twoMemberFormData);
@@ -348,10 +344,7 @@ describe('ProgramCard - Eligibility Tags', () => {
       });
 
       const program = createProgram({
-        members: [
-          createMemberEligibility('hoh', true, 100),
-          createMemberEligibility('child-1', true, 50),
-        ],
+        members: [createMemberEligibility('hoh', true, 100), createMemberEligibility('child-1', true, 50)],
       });
 
       renderProgramCard(program, configWithFlag(true), twoMemberFormData);

--- a/src/Components/Results/Programs/ProgramCard.tsx
+++ b/src/Components/Results/Programs/ProgramCard.tsx
@@ -6,7 +6,7 @@ import ResultsTranslate from '../Translate/Translate';
 import { useContext, useMemo } from 'react';
 import { useMediaQuery } from '@mui/material';
 import './ProgramCard.css';
-import { findValidationForProgram, useResultsContext, useResultsLink } from '../Results';
+import { useResultsLink } from '../Results';
 import { FormattedMessageType } from '../../../Types/Questions';
 import { BREAKPOINTS } from '../../../utils/breakpoints';
 import { Context } from '../../Wrapper/Wrapper';
@@ -152,30 +152,10 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
   const estimatedAppTime = program.estimated_application_time;
   const programName = program.name;
   const programId = program.program_id;
-  const { validations, isAdminView } = useResultsContext();
   const { formData } = useContext(Context);
   const relationshipOptions = useConfig<{ [key: string]: FormattedMessageType }>('relationship_options');
   const showEligibilityTags = useFeatureFlag('eligibility_tags');
   const track = useTrackEvent();
-
-  const containerClass = useMemo(() => {
-    const classNames = [];
-    const validation = findValidationForProgram(validations, program);
-
-    if (validation === undefined || !isAdminView) {
-      return [];
-    }
-
-    const passed = Number(validation.value) === program.estimated_value && validation.eligible === program.eligible;
-
-    if (passed) {
-      classNames.push('passed');
-    } else {
-      classNames.push('failed');
-    }
-
-    return classNames;
-  }, [isAdminView, validations, program]);
 
   const flags = useMemo(() => {
     const flags: ResultsCardFlag[] = [];
@@ -287,7 +267,6 @@ const ProgramCard = ({ program }: ProgramCardProps) => {
       }}
       flags={flags}
       link={programPageLink}
-      containerClassNames={containerClass}
       eligibleMembers={eligibleMembers}
       onMoreInfoClick={handleMoreInfoClick}
     />

--- a/src/Components/Results/Programs/Programs.tsx
+++ b/src/Components/Results/Programs/Programs.tsx
@@ -1,5 +1,5 @@
 import { ProgramCategory } from '../../../Types/Results';
-import { findValidationForProgram, useResultsContext } from '../Results';
+import { useResultsContext } from '../Results';
 import Filter from '../Filter/Filter';
 import ProgramCard from './ProgramCard';
 import CategoryHeading from '../CategoryHeading/CategoryHeading';
@@ -45,44 +45,6 @@ function sortProgramsIntoCategories(categories: ProgramCategory[]): ProgramCateg
   return sortedCategories;
 }
 
-const ValidationCategory = () => {
-  const { programs, isAdminView, validations } = useResultsContext();
-
-  const validationPrograms = useMemo(
-    () => programs.filter((program) => findValidationForProgram(validations, program) !== undefined),
-    [validations, programs],
-  );
-
-  const validationCategory = useMemo<ProgramCategory>(() => {
-    return {
-      external_name: 'validation_category',
-      icon: '',
-      name: { label: 'programs.categories.validation.header', default_message: 'Validations' },
-      description: { label: '', default_message: '' },
-      caps: [],
-      programs: validationPrograms,
-      priority: null,
-      tax_category: false,
-    };
-  }, [validationPrograms]);
-
-  if (!isAdminView || validationPrograms.length === 0) {
-    return null;
-  }
-
-  return (
-    <>
-      <CategoryHeading category={validationCategory} />
-      {validationPrograms.map((program) => {
-        // Key by identity, not index: filtering reorders programs, and an
-        // index key would reuse a card instance (and its already-tripped
-        // impression ref) for a different program, dropping its impression.
-        return <ProgramCard program={program} key={program.program_id} />;
-      })}
-    </>
-  );
-};
-
 // Opens the Benbot chat window with an initial "guide me" prompt.
 // Only rendered when the 'benbot' flag is on (so it's always inside ChatbotProvider).
 const GuideMeButton = () => {
@@ -121,7 +83,6 @@ const Programs = () => {
       <ResultsMessage />
       {!isEnergyCalculator && <Filter />}
       {isEnergyCalculator && <DocumentSummary programs={programs} />}
-      <ValidationCategory />
       {isBenbotEnabled && (
         <div className="results-action-buttons">
           <GuideMeButton />

--- a/src/Components/Results/Results.tsx
+++ b/src/Components/Results/Results.tsx
@@ -8,7 +8,6 @@ import {
   Program,
   ProgramCategory,
   UrgentNeed,
-  Validation,
 } from '../../Types/Results';
 import { getEligibility, AssistantVisibleProgram } from '../../apiCalls';
 import { Context } from '../Wrapper/Wrapper';
@@ -69,8 +68,6 @@ type WrapperResultsContext = {
   setFilterState: (newFilterState: FilterState) => void;
   missingPrograms: boolean;
   isAdminView: boolean;
-  validations: Validation[];
-  setValidations: (validations: Validation[]) => void;
   energyCalculatorRebateCategories: EnergyCalculatorRebateCategory[];
   policyEngineData: PolicyEngineData | undefined;
   externalApiFailures: string[];
@@ -104,10 +101,6 @@ export function findMemberEligibilityMember(formData: FormData, memberEligibilit
 
 export function findProgramById(programs: Program[], id: number) {
   return programs.find((program) => program.program_id === id);
-}
-
-export function findValidationForProgram(validations: Validation[], program: Program) {
-  return validations.find((validation) => validation.program_name === program.external_name);
 }
 
 export function useResultsLink(link: string) {
@@ -177,7 +170,6 @@ const Results = ({ type }: ResultsProps) => {
   const [needs, setNeeds] = useState<UrgentNeed[]>([]);
   const [missingPrograms, setMissingPrograms] = useState(false);
   const [externalApiFailures, setExternalApiFailures] = useState<string[]>([]);
-  const [validations, setValidations] = useState<Validation[]>([]);
   const energyCalculatorRebateCategories = useFetchEnergyCalculatorRebates();
 
   // The programs shown on load — run through the same filterPrograms pipeline the
@@ -289,7 +281,7 @@ const Results = ({ type }: ResultsProps) => {
 
   const filterPrograms = useMemo(
     () => filterProgramsGenerator(formData, filterState, isAdminView),
-    [formData, filterState, isAdminView]
+    [formData, filterState, isAdminView],
   );
 
   // What BenBot is allowed to recommend from — see BenbotWrapper and
@@ -303,7 +295,6 @@ const Results = ({ type }: ResultsProps) => {
       setProgramCategories([]);
       setMissingPrograms(false);
       setExternalApiFailures([]);
-      setValidations([]);
       setPolicyEngineData(undefined);
       return;
     }
@@ -326,7 +317,6 @@ const Results = ({ type }: ResultsProps) => {
     );
     setMissingPrograms(apiResults.missing_programs);
     setExternalApiFailures(apiResults.external_api_failures ?? []);
-    setValidations(apiResults.validations);
     setLoading(false);
     setPolicyEngineData(apiResults.pe_data);
   }, [filterPrograms, apiResults, isEnergyCalculator, energyCalculatorRebateCategories]);
@@ -342,8 +332,6 @@ const Results = ({ type }: ResultsProps) => {
           setFilterState,
           missingPrograms,
           isAdminView,
-          validations,
-          setValidations,
           energyCalculatorRebateCategories: energyCalculatorRebateCategories ?? [],
           policyEngineData,
           externalApiFailures,
@@ -388,7 +376,12 @@ const Results = ({ type }: ResultsProps) => {
             <ResultsHeader type={type} />
             <div className="results-card-wrapper">
               <ResultsTabs />
-              <div id="results-tabpanel" role="tabpanel" aria-labelledby={type === 'program' ? 'long-term-benefits-tab' : 'near-term-benefits-tab'} className="benefits-form results-card-body">
+              <div
+                id="results-tabpanel"
+                role="tabpanel"
+                aria-labelledby={type === 'program' ? 'long-term-benefits-tab' : 'near-term-benefits-tab'}
+                className="benefits-form results-card-body"
+              >
                 {type === 'program' && <ExternalApiFailureBanner />}
                 {type === 'program' && <UrgentNeedBanner />}
                 <Grid container sx={{ pt: '1rem' }}>

--- a/src/Components/Results/testHelpers.ts
+++ b/src/Components/Results/testHelpers.ts
@@ -11,7 +11,7 @@ export const createMemberEligibility = (
   id: string,
   eligible: boolean = true,
   value: number = 100,
-  already_has: boolean = false
+  already_has: boolean = false,
 ): MemberEligibility => ({
   frontend_id: id,
   eligible,
@@ -51,40 +51,38 @@ export const createProgram = (overrides: Partial<Program> = {}): Program => ({
   ...overrides,
 });
 
-export const createFormData = (overrides: Partial<FormData> = {}): FormData => ({
-  isTest: false,
-  frozen: false,
-  agreeToTermsOfService: true,
-  is13OrOlder: true,
-  zipcode: '60601',
-  county: 'Cook',
-  startTime: new Date().toISOString(),
-  hasExpenses: 'false',
-  expenses: [],
-  householdSize: 1,
-  householdData: [],
-  householdAssets: 0,
-  hasBenefits: 'false',
-  benefits: [],
-  signUpInfo: {
-    email: '',
-    phone: '',
-    firstName: '',
-    lastName: '',
-    hasUser: false,
-    sendOffers: false,
-    sendUpdates: false,
-    commConsent: false,
-  },
-  acuteHHConditions: {},
-  referrerCode: '',
-  immutableReferrer: '',
-  ...overrides,
-} as FormData);
+export const createFormData = (overrides: Partial<FormData> = {}): FormData =>
+  ({
+    isTest: false,
+    agreeToTermsOfService: true,
+    is13OrOlder: true,
+    zipcode: '60601',
+    county: 'Cook',
+    startTime: new Date().toISOString(),
+    hasExpenses: 'false',
+    expenses: [],
+    householdSize: 1,
+    householdData: [],
+    householdAssets: 0,
+    hasBenefits: 'false',
+    benefits: [],
+    signUpInfo: {
+      email: '',
+      phone: '',
+      firstName: '',
+      lastName: '',
+      hasUser: false,
+      sendOffers: false,
+      sendUpdates: false,
+      commConsent: false,
+    },
+    acuteHHConditions: {},
+    referrerCode: '',
+    immutableReferrer: '',
+    ...overrides,
+  } as FormData);
 
-export const createFilterState = (
-  selectedCitizenship: CitizenLabelOptions = 'citizen'
-): FilterState => ({
+export const createFilterState = (selectedCitizenship: CitizenLabelOptions = 'citizen'): FilterState => ({
   selectedCitizenship,
   calculatedFilters: new Set(),
 });
@@ -94,27 +92,28 @@ export const createProgramWithExclusions = (
   name: string,
   excludes: number[] = [],
   eligible: boolean = true,
-  value: number = 100
-): Program => createProgram({
-  program_id: id,
-  name: createTranslation(name),
-  name_abbreviated: name.substring(0, 3).toUpperCase(),
-  eligible,
-  estimated_value: value,
-  household_value: value,
-  excludes_programs: excludes.length > 0 ? excludes : null,
-});
+  value: number = 100,
+): Program =>
+  createProgram({
+    program_id: id,
+    name: createTranslation(name),
+    name_abbreviated: name.substring(0, 3).toUpperCase(),
+    eligible,
+    estimated_value: value,
+    household_value: value,
+    excludes_programs: excludes.length > 0 ? excludes : null,
+  });
 
 export const createProgramWithMembers = (
   id: number,
   name: string,
   memberValues: { [key: string]: number },
-  legalStatus: string[] = ['citizen']
+  legalStatus: string[] = ['citizen'],
 ): Program => {
   const members = Object.entries(memberValues).map(([memberId, value]) =>
-    createMemberEligibility(memberId, true, value)
+    createMemberEligibility(memberId, true, value),
   );
-  
+
   return createProgram({
     program_id: id,
     name: createTranslation(name),

--- a/src/Components/Steps/Expenses/Expenses.test.tsx
+++ b/src/Components/Steps/Expenses/Expenses.test.tsx
@@ -52,7 +52,6 @@ jest.mock('../../../Assets/stepDirectory', () => ({
 
 const baseFormData: FormData = {
   isTest: false,
-  frozen: false,
   externalID: undefined,
   agreeToTermsOfService: false,
   is13OrOlder: false,

--- a/src/Components/Wrapper/Wrapper.tsx
+++ b/src/Components/Wrapper/Wrapper.tsx
@@ -16,7 +16,6 @@ const EMPTY_REFERRAL_OPTIONS: ReferralOptions = { generic: {}, partners: {} };
 
 const initialFormData: FormData = {
   isTest: false,
-  frozen: false,
   externalID: undefined,
   agreeToTermsOfService: false,
   is13OrOlder: false,

--- a/src/Types/ApiCalls.ts
+++ b/src/Types/ApiCalls.ts
@@ -49,13 +49,6 @@ export type UrgentNeedTypeResponse = {
   }[];
 }[];
 
-export type ValidationRequestData = {
-  screen_uuid: string;
-  program_name: string;
-  eligible: boolean;
-  value: number;
-};
-
 export type AdminTokenResponse = {
   token: string;
 };

--- a/src/Types/ApiFormData.ts
+++ b/src/Types/ApiFormData.ts
@@ -122,7 +122,6 @@ export type ApiUser = {
 
 export type ApiFormDataReadOnly = {
   id: number;
-  frozen: boolean;
   uuid: string;
   submision_date: string | null;
   last_email_request_date: string | null;

--- a/src/Types/FormData.ts
+++ b/src/Types/FormData.ts
@@ -89,7 +89,6 @@ export type AcuteHHConditions = { [key: string]: boolean };
 export type FormData = {
   isTest: boolean;
   isTestData?: boolean;
-  frozen: boolean;
   externalID?: string;
   agreeToTermsOfService: boolean;
   is13OrOlder: boolean;

--- a/src/Types/Results.ts
+++ b/src/Types/Results.ts
@@ -98,14 +98,6 @@ export type UrgentNeed = {
   notification_message: Translation | null;
 };
 
-export type Validation = {
-  id: number;
-  screen_uuid: string;
-  program_name: string;
-  eligible: boolean;
-  value: string;
-};
-
 export type EligibilityResults = {
   programs: Program[];
   program_categories: ProgramCategory[];
@@ -113,7 +105,6 @@ export type EligibilityResults = {
   screen_id: number;
   default_language: string;
   missing_programs: boolean;
-  validations: Validation[];
   created_date: string;
   pe_data: PolicyEngineData;
   // Ids of external APIs (e.g. "policy_engine") that failed while the backend computed

--- a/src/apiCalls.ts
+++ b/src/apiCalls.ts
@@ -8,7 +8,6 @@ import {
   TranslationResponse,
   UrgentNeedTypeResponse,
   UserRequestData,
-  ValidationRequestData,
 } from './Types/ApiCalls';
 import { ApiFormData, ApiFormDataReadOnly } from './Types/ApiFormData';
 import { EligibilityResults } from './Types/Results';
@@ -25,7 +24,6 @@ const apiUrgentNeedTypesEndpoint = `${domain}/api/urgent_need_types/`;
 export const configEndpoint = `${domain}/api/configuration/`;
 const screenerOptionsEndpoint = `${domain}/api/screener-options/`;
 const eligibilityEndpoint = `${domain}/api/eligibility/`;
-const validationEndpoint = `${domain}/api/validations/`;
 const authTokenEndpoint = `${domain}/api/auth-token/`;
 const getNpsEndpoint = (uuid: string) => `${domain}/api/screens/${uuid}/nps/`;
 const assistantConversationsEndpoint = (uuid: string) => `${domain}/api/screens/${uuid}/assistant/conversations/`;
@@ -190,42 +188,6 @@ const getAllNearTermPrograms = async (whiteLabel: string) => {
     types.push({ ...rest, programs: urgentNeeds });
   }
   return types;
-};
-
-const postValidation = async (validationBody: ValidationRequestData, key: string) => {
-  const staffHeader = {
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-    Authorization: 'Token ' + key,
-  };
-
-  return await fetch(validationEndpoint, {
-    method: 'POST',
-    headers: staffHeader,
-    body: JSON.stringify(validationBody),
-  }).then((response) => {
-    if (!response.ok) {
-      throw new Error(`${response.status} ${response.statusText}`);
-    }
-    return response.json();
-  });
-};
-
-const deleteValidation = async (validationid: number, key: string) => {
-  const staffHeader = {
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-    Authorization: 'Token ' + key,
-  };
-
-  return await fetch(validationEndpoint + validationid, {
-    method: 'DELETE',
-    headers: staffHeader,
-  }).then((response) => {
-    if (!response.ok) {
-      throw new Error(`${response.status} ${response.statusText}`);
-    }
-  });
 };
 
 type NPSScoreData = {
@@ -425,8 +387,6 @@ export {
   getEligibility,
   getAllLongTermPrograms,
   getAllNearTermPrograms,
-  postValidation,
-  deleteValidation,
   getAuthToken,
   postNPSScore,
   patchNPSReason,


### PR DESCRIPTION
Closes [MFB-1567](https://linear.app/myfriendben/issue/MFB-1567/test-machinery-retire-old-validation-dbharnessworkflow) (frontend half).

**Depends on MyFriendBen/benefits-api#1708 — merge that first.** It removes the `validations` array from the results payload and drops the `api/validations/` endpoint, which is what this PR stops reading.

## Context

The legacy validation system is being retired. Its frontend surface was an admin-only workflow: a staff user viewing results could record what a program's expected eligibility and value *should* be, and the UI would render expected-vs-actual side by side with pass/fail card coloring.

## Removed

- `postValidation` / `deleteValidation` and the `validations` endpoint in [`apiCalls.ts`](src/apiCalls.ts)
- `Validation` and `ValidationRequestData` types
- `validations` / `setValidations` from the results context, and `findValidationForProgram`
- the admin-only **Validations** program category in [`Programs.tsx`](src/Components/Results/Programs/Programs.tsx)
- **Create/Remove Validation** buttons and their handlers in [`ProgramPage.tsx`](src/Components/Results/ProgramPage/ProgramPage.tsx)
- expected-vs-actual value rendering in [`FormattedValue.tsx`](src/Components/Results/FormattedValue.tsx) and the `.passed` / `.failed` card styling
- the frozen-screen header banner and its styles ([`Header.tsx`](src/Components/Header/Header.tsx), [`Header.css`](src/Components/Header/Header.css))

## On the frozen banner

`Screen.frozen` was computed backend-side as `validations.count() > 0` — the presence of validation rows was its only trigger. With the table dropped the field is permanently `false`, so the banner ("This screen is frozen. Changes you make will not be saved.") could never render again, and the backend write guard it warned about no longer fires.

Verified against production before removing: all **537 frozen screens are test fixtures** (`is_test_data`), created by the `import_validations` command. No real household screens lose edit protection.

`useOverrideValue` keeps its `estimated_value_override` behavior — that's a separate feature and untouched. It just loses the `expectedValue` parameter and the `isAdminView` branch that only validations fed.

## Also in this PR

`Header.tsx`'s container-class memo had an empty dependency array while reading `getReferrer('uiOptions')`, so it captured the first-render referrer value. `Wrapper` sets the referrer in a post-mount effect, meaning the `white_header` / `small_header_language_dropdown` classes could be computed against a stale referrer and never refresh. Previously the memo depended on `formData.frozen`, which incidentally changed when formData loaded and masked the bug; removing that dep exposed it. Fixed by hoisting the resolved value and depending on it. (Caught by CodeRabbit.)

## Verification

- `1093 tests passed` across `83 suites`
- `npm run lint` — 0 errors (2 pre-existing warnings in `Textfield.js`, untouched)
- `prettier --check` clean on all changed files
- `tsc --noEmit` reports **29 errors, identical to `main`** — verified by stashing this branch's changes and re-running. None are in files this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed validation-related results, controls, and API interactions.
  * Removed the frozen-screen header state and associated messaging.
  * Simplified result displays by removing validation status styling and expected-value annotations.

* **Bug Fixes**
  * Updated form handling to prevent obsolete frozen-state data from being retained.

* **Refactor**
  * Streamlined program pages, result cards, and supporting data structures after removing validation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
